### PR TITLE
ID-966: Refactor - Disable logging/events when manual sessions are enabled but not started

### DIFF
--- a/AppAmbitMaui/Analytics.cs
+++ b/AppAmbitMaui/Analytics.cs
@@ -13,9 +13,6 @@ namespace AppAmbit;
 public static class Analytics
 {
     internal static bool _isManualSessionEnabled = false;
-    private static string? _sessionId = null;
-    private static bool _isSessionActive = false;
-    private static EndSession? _currentEndSession = null;
     private static IAPIService? _apiService;
     private static IStorageService? _storageService;
 
@@ -33,30 +30,12 @@ public static class Analytics
 
     public static async Task StartSession()
     {
-        Debug.WriteLine("StartSession called");
-        if (_isSessionActive)
-        {
-            return;
-        }
-
-        var response = await _apiService?.ExecuteRequest<SessionResponse>(new StartSessionEndpoint());
-        _sessionId = response.SessionId;
-        _storageService?.SetSessionId(response.SessionId);
-        _isSessionActive = true;
+        await SessionManager.StartSession();
     }
 
     public static async Task EndSession()
     {
-        Debug.WriteLine("EndSession called");
-        if (!_isSessionActive)
-        {
-            Debug.WriteLine("Session didn't started");
-            return;
-        }
-        var sessionId = await _storageService?.GetSessionId();
-        await _apiService?.ExecuteRequest<EndSessionResponse>(new EndSessionEndpoint(sessionId));
-        _sessionId = null;
-        _isSessionActive = false;
+        await SessionManager.EndSession();
     }
 
     public static async void SetUserId(string userId)
@@ -92,25 +71,9 @@ public static class Analytics
         await SendOrSaveEvent(eventTitle, data);
     }
 
-    public static async void SendEndSessionIfExists()
-    {
-        if (_currentEndSession == null)
-        {
-            var file = GetFilePath(GetFileName(typeof(EndSession)));
-            Debug.WriteLine($"file:{file}");
-            var endSession = await GetSavedSingleObject<EndSession>();
-            if (endSession == null)
-                return;
-            _currentEndSession = endSession;
-        }
-        await _apiService?.ExecuteRequest<EndSessionResponse>(new EndSessionEndpoint(_currentEndSession));
-        _currentEndSession = null;
-        _isSessionActive = false;
-    }
-
     private static async Task SendOrSaveEvent(string eventTitle, Dictionary<string, string> data = null)
     {
-        if (!ShouldSendEvent)
+        if (!SessionManager.IsSessionActive)
         {
             return;
         }
@@ -172,28 +135,6 @@ public static class Analytics
         Debug.WriteLine("Events batch sent");
     }
 
-    public static async Task SaveEndSession()
-    {
-        var sessionId = _sessionId ?? await _storageService?.GetSessionId();
-        var endSession = new EndSession() { Id = sessionId, Timestamp = DateUtils.GetUtcNow };
-        var json = JsonConvert.SerializeObject(endSession, Formatting.Indented);
 
-        SaveToFile<EndSession>(json);
-    }
-
-    internal static async Task RemoveSavedEndSession()
-    {
-        _ = await GetSavedSingleObject<EndSession>();
-    }
-
-    internal static bool ShouldSendEvent
-    {
-        get
-        {
-            if (!_isManualSessionEnabled)
-                return true;
-
-            return _isSessionActive;
-        }
-    }
+ 
 }

--- a/AppAmbitMaui/Core.cs
+++ b/AppAmbitMaui/Core.cs
@@ -95,12 +95,13 @@ public static class Core
 
     private static async Task OnResume()
     {
+
         if (!TokenIsValid())
             await InitializeConsumer();
         
         if (!Analytics._isManualSessionEnabled)
         {
-            await Analytics.RemoveSavedEndSession();
+            await SessionManager.RemoveSavedEndSession();
         }
         
         await Crashes.SendBatchLogs();
@@ -111,7 +112,7 @@ public static class Core
     {
         if (!Analytics._isManualSessionEnabled)
         {
-            await Analytics.SaveEndSession();
+            await SessionManager.SaveEndSession();
         }
     }
     
@@ -119,7 +120,7 @@ public static class Core
     {
         if (!Analytics._isManualSessionEnabled)
         {
-            await Analytics.SaveEndSession();
+            await SessionManager.SaveEndSession();
         }
     }
 
@@ -173,8 +174,8 @@ public static class Core
         
         if (!Analytics._isManualSessionEnabled)
         {
-            Analytics.SendEndSessionIfExists();
-            await Analytics.StartSession();
+            await SessionManager.SendEndSessionIfExists();
+            await SessionManager.StartSession();
         }
     }
 
@@ -185,6 +186,7 @@ public static class Core
         storageService = Application.Current?.Handler?.MauiContext?.Services.GetService<IStorageService>();
         await storageService?.InitializeAsync();
         var deviceId = await storageService.GetDeviceId();
+        SessionManager.Initialize(apiService, storageService);
         Crashes.Initialize(apiService,storageService,deviceId);
         Analytics.Initialize(apiService,storageService);
     }

--- a/AppAmbitMaui/Crashes.cs
+++ b/AppAmbitMaui/Crashes.cs
@@ -16,7 +16,7 @@ public static class Crashes
     private static string _deviceId;
     private static bool _didCrashInLastSession = false;
     private static readonly SemaphoreSlim _ensureFileLocked = new SemaphoreSlim(1,1);
-    
+
     internal static void Initialize(IAPIService? apiService, IStorageService? storageService, string deviceId)
     {
         AppDomain.CurrentDomain.UnhandledException -= OnUnhandledException;
@@ -111,7 +111,7 @@ public static class Crashes
         if (unhandledExceptionEventArgs.ExceptionObject is not Exception ex)
             return;
 
-        if (Analytics.ShouldSendEvent)
+        if (SessionManager.IsSessionActive)
         {
             var info = ExceptionInfo.FromException(ex, _deviceId);
             var json = JsonConvert.SerializeObject(info, Formatting.Indented);
@@ -171,6 +171,8 @@ public static class Crashes
             Debug.WriteLine("No logs to send");
             return;
         }
+
+        Debug.WriteLine($"SendBatchLogs: {logEntityList?.Count}");
 
         Debug.WriteLine("Sending logs in batch");
         var logBatch = new LogBatch() { Logs = logEntityList };

--- a/AppAmbitMaui/SessionManager.cs
+++ b/AppAmbitMaui/SessionManager.cs
@@ -1,0 +1,98 @@
+using System.Diagnostics;
+using AppAmbit.Models.Responses;
+using AppAmbit.Services.Endpoints;
+using AppAmbit.Services.Interfaces;
+using AppAmbit.Models.Analytics;
+using static AppAmbit.FileUtils;
+using Newtonsoft.Json;
+using Shared.Utils;
+
+
+namespace AppAmbit;
+
+internal class SessionManager
+{
+    private static string? _sessionId = null;
+    private static bool _isSessionActive = false;
+    private static IAPIService? _apiService;
+    private static IStorageService? _storageService;
+    private static EndSession? _currentEndSession = null;
+
+    public static string? SessionId { get => _sessionId; }
+    public static bool IsSessionActive { get => _isSessionActive;}
+
+
+    internal static void                                                                                                                      Initialize(IAPIService? apiService, IStorageService? storageService)
+    {
+        _apiService = apiService;
+        _storageService = storageService;
+    }
+
+    public static async Task StartSession()
+    {
+        Debug.WriteLine("StartSession called");
+        if (_isSessionActive)
+        {
+            return;
+        }
+
+        SessionResponse? response = await _apiService?.ExecuteRequest<SessionResponse>(new StartSessionEndpoint());
+        _sessionId = response?.SessionId;
+        _storageService?.SetSessionId(response!.SessionId);
+        _isSessionActive = true;
+    }
+
+    public static async Task EndSession()
+    {
+        if (!_isSessionActive)
+        {
+            return;
+        }
+
+        string? sessionId = await _storageService?.GetSessionId();
+        await EndSessionASync(sessionId: sessionId);
+    }
+
+    public static async Task SendEndSessionIfExists()
+    {
+        if (_currentEndSession == null)
+        {
+            var file = GetFilePath(GetFileName(typeof(EndSession)));
+            Debug.WriteLine($"file:{file}");
+            var endSession = await GetSavedSingleObject<EndSession>();
+            if (endSession == null)
+                return;
+            _currentEndSession = endSession;
+        }
+        await EndSessionASync(endSession: _currentEndSession);
+        _currentEndSession = null;
+
+    }
+
+
+    public static async Task SaveEndSession()
+    {
+        var sessionId = _sessionId ?? await _storageService?.GetSessionId();
+        var endSession = new EndSession() { Id = sessionId, Timestamp = DateUtils.GetUtcNow };
+        var json = JsonConvert.SerializeObject(endSession, Formatting.Indented);
+
+        SaveToFile<EndSession>(json);
+    }
+
+   public static async Task RemoveSavedEndSession()
+    {
+        _ = await GetSavedSingleObject<EndSession>();
+    }   
+
+    private static async Task EndSessionASync(string? sessionId = null, EndSession? endSession = null)
+    {
+        var endpoint = endSession != null
+            ? new EndSessionEndpoint(endSession)
+            : new EndSessionEndpoint(sessionId!);
+
+        await _apiService?.ExecuteRequest<EndSessionResponse>(endpoint);
+        _sessionId = null;
+        _isSessionActive = false;
+    }
+ 
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🛠️ Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📚 Documentation Update

## Description

This PR updates the session tracking behavior when manual mode is enabled.  
If manual mode is active **and no session has been started**, the SDK will skip sending logs and events.  
If a session is active, tracking functions as expected.  
When manual mode is disabled, the SDK behaves as normal (tracking always enabled).

This change ensures unnecessary tracking does not occur when manual control is intended.

## Related Tickets & Documents

- Closes [ID966](https://app.asana.com/1/1203353714760101/project/1204450899416459/task/1210163213023392)

## QA Instructions, Screenshots, Recordings

### ✅ Manual mode with active session
1. Enable manual mode
2. Launch the application
3. Click **"Start Session"**
4. Send a log or event
5. Confirm the data appears in the dashboard

### ❌ Manual mode without session
1. Enable manual mode
2. Launch the application
3. Do **not** start a session
4. Send a log or event
5. Confirm it is **not** logged in the dashboard

### ✅ Normal mode
1. Disable manual mode
2. Launch the application
3. Send a log or event
4. Confirm the log appears in the dashboard

## Added/updated tests?

- [ ] ✅ Yes
- [x] ❌ No, and this is why: This is SDK logic controlled by runtime flags; existing test coverage does not require change.
- [ ] 🤔 I need help with writing tests

## Are there any post deployment tasks we need to perform?
- [ ] 📝 Yes (please add details)
- [x] ❌ No
- [ ] ❓ I don't know

## [optional] What gif best describes this PR or how it makes you feel?
[[![Victory](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExYnZjY283YXUxZHB1aHR2MnNuczd0dzB6b256dzhrZWRxeDVwMHc5aSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3Owa0TWYqHi5RZYGql/giphy.gif)]
