### PR TITLE
ID-981: Bug Fix - Fix: app crash on startup after clearing app data

### DIFF
--- a/AppAmbitTestingApp/AppAmbitTestingApp.csproj
+++ b/AppAmbitTestingApp/AppAmbitTestingApp.csproj
@@ -38,28 +38,32 @@
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-android|AnyCPU'">
+      <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
+    </PropertyGroup>
+
     <ItemGroup>
         <!-- App Icon -->
-        <MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4"/>
+        <MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />
 
         <!-- Splash Screen -->
-        <MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#512BD4" BaseSize="128,128"/>
+        <MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#512BD4" BaseSize="128,128" />
 
         <!-- Images -->
-        <MauiImage Include="Resources\Images\*"/>
-        <MauiImage Update="Resources\Images\dotnet_bot.png" Resize="True" BaseSize="300,185"/>
+        <MauiImage Include="Resources\Images\*" />
+        <MauiImage Update="Resources\Images\dotnet_bot.png" Resize="True" BaseSize="300,185" />
 
         <!-- Custom Fonts -->
-        <MauiFont Include="Resources\Fonts\*"/>
+        <MauiFont Include="Resources\Fonts\*" />
 
         <!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
-        <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)"/>
+        <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)"/>
-        <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1"/>
+        <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+        <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🛠️ Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📚 Documentation Update

## Description

By default, MAUI uses Fast Deployment during development, which libraries stores certain essential components—including assemblies and native—in the user data directory. When the app data is cleared, these dependencies are deleted, leading to application crashes on the next launch.

## Related Tickets & Documents

* https://app.asana.com/1/1203353714760101/project/1204450899416459/task/1210177971747547?focus=true

## QA Instructions, Screenshots, Recordings

Replicate this bug:

* Step 1: Install the app (AmbitTestingApp)
* Step 2: Crash the app once or twice
* Step 3: Clear all app data.
* Step 4: Try to open the app.(If you follow these steps you should be having problems entering the application and they will not be resolved until you reinstall it.)

Steps to resolve this bug:

- Open the project settings: Right-click on your Android project and select Properties.
- Navigate to Android Options: In the left pane, go to Android Options.
- Adjust packaging settings: Under the Packaging section, uncheck Use Fast Deployment (debug mode only) to disable incremental deployment and ensure full APK rebuilds.


## Added/updated tests?

- [ ] ✅ Yes
- [x] ❌ No, and this is why: _please replace this line with details on why tests
  have not been included_
- [ ] 🤔 I need help with writing tests

## Are there any post deployment tasks we need to perform?
- [ ] 📝 Yes (please add details)
- [x] ❌ No
- [ ] ❓ I don't know

## [optional] What gif best describes this PR or how it makes you feel?
![Alt Text](https://media.giphy.com/media/xNBcChLQt7s9a/giphy.gif?cid=790b76110nm03zf29woxqwx7euymmffakb8valf74ione1sn&ep=v1_gifs_search&rid=giphy.gif&ct=g)
```
