### PR TITLE
ID-976: Feature - A daily error is sent for the last 30 days.

### DIFF
--- a/AppAmbitMaui/Crashes.cs
+++ b/AppAmbitMaui/Crashes.cs
@@ -38,10 +38,10 @@ public static class Crashes
         await Logging.LogEvent("", LogType.Error, exception, properties, classFqn, fileName, lineNumber);
     }
 
-    public static async Task LogError(string message, Dictionary<string, string> properties = null, string? classFqn = null, Exception? exception = null, [CallerFilePath] string? fileName = null, [CallerLineNumber] int? lineNumber = null)
+    public static async Task LogError(string message, Dictionary<string, string> properties = null, string? classFqn = null, Exception? exception = null, [CallerFilePath] string? fileName = null, [CallerLineNumber] int? lineNumber = null, DateTime? createdAt = null)
     {
         classFqn = classFqn ?? await GetCallerClassAsync();
-        await Logging.LogEvent(message, LogType.Error, exception, properties, classFqn, fileName, lineNumber);
+        await Logging.LogEvent(message, LogType.Error, exception, properties, classFqn, fileName, lineNumber, createdAt);
     }
 
     public static async Task GenerateTestCrash()

--- a/AppAmbitMaui/Logging.cs
+++ b/AppAmbitMaui/Logging.cs
@@ -17,14 +17,14 @@ internal static class Logging
         _storageService = storageService;
     }
 
-    public static async Task LogEvent(string? message, LogType logType, Exception? exception = null, Dictionary<string, string>? properties = null, string? classFqn = null, string? fileName = null, int? lineNumber = null)
+    public static async Task LogEvent(string? message, LogType logType, Exception? exception = null, Dictionary<string, string>? properties = null, string? classFqn = null, string? fileName = null, int? lineNumber = null, DateTime? createdAt = null)
     {
         var deviceId = await _storageService.GetDeviceId();
         var exceptionInfo = (exception != null) ? ExceptionInfo.FromException(exception, deviceId) : null;
-        LogEvent(message, logType, exceptionInfo, properties, classFqn, fileName, lineNumber);
+        await LogEvent(message, logType, exceptionInfo, properties, classFqn, fileName, lineNumber, createdAt);
     }
 
-    public static async Task LogEvent(string? message, LogType logType, ExceptionInfo exception = null, Dictionary<string, string>? properties = null, string? classFqn = null, string? fileName = null, int? lineNumber = null)
+    public static async Task LogEvent(string? message, LogType logType, ExceptionInfo? exception = null, Dictionary<string, string>? properties = null, string? classFqn = null, string? fileName = null, int? lineNumber = null, DateTime? createdAt = null)
     {
         if (!SessionManager.IsSessionActive)
             return;
@@ -43,7 +43,7 @@ internal static class Logging
             Context = properties ?? new Dictionary<string, string>(),
             Type = logType,
             File = (logType == LogType.Crash && exception != null) ? file : null,
-            CreatedAt = DateUtils.GetUtcNow,
+            CreatedAt = createdAt != null ? createdAt.Value : DateTime.UtcNow,
         };
         await SendOrSaveLogEventAsync(log);
     }
@@ -73,7 +73,6 @@ internal static class Logging
     {
         var logEntity = log.ConvertTo<LogEntity>();
         logEntity.Id = Guid.NewGuid();
-        logEntity.CreatedAt = DateUtils.GetUtcNow;
 
         await _storageService?.LogEventAsync(logEntity);
     }

--- a/AppAmbitTestingApp/MainPage.xaml
+++ b/AppAmbitTestingApp/MainPage.xaml
@@ -73,6 +73,9 @@
                 Text="Send ClassInfo LogError" 
                 Clicked="OnSendTestLogWithClassFQN" />
             <Button
+                Text="Generate the last 30 daily errors"
+                Clicked="OnGenerate30daysTestErrors" />
+            <Button
                 Text="Generates the last 30 daily crashes"
                 Clicked="OnGenerate30daysTestCrash" />
             <Button

--- a/AppAmbitTestingApp/MainPage.xaml.cs
+++ b/AppAmbitTestingApp/MainPage.xaml.cs
@@ -122,6 +122,23 @@ public partial class MainPage : ContentPage
         await DisplayAlert("Info", "LogError Sent", "Ok");
     }
 
+    private async void OnGenerate30daysTestErrors(object sender, EventArgs e)
+    {
+        if (Connectivity.Current.NetworkAccess == NetworkAccess.Internet)
+        {
+            await DisplayAlert("Info", "Turn off internet and try again", "Ok");
+            return;
+        }
+        foreach (int index in Range(start: 1, count: 30))
+        {
+            var errorsDate = DateUtils.GetUtcNow.AddDays(-(30 - index));
+            Debug.WriteLine($"DEBUG TIME ERROR: {errorsDate} : Index: {index}");
+            await Crashes.LogError("Test 30 Last Days Errors", createdAt: errorsDate);
+            await Task.Delay(500);
+        }
+        await DisplayAlert("Info", "Logs generated, turn on internet", "Ok");
+    }
+
     private async void OnGenerate30daysTestCrash(object sender, EventArgs e)
     {
         if (Connectivity.Current.NetworkAccess == NetworkAccess.Internet)

--- a/AppAmbitTestingApp/MauiProgram.cs
+++ b/AppAmbitTestingApp/MauiProgram.cs
@@ -12,7 +12,7 @@ public static class MauiProgram
         var builder = MauiApp.CreateBuilder();
         builder
             .UseMauiApp<App>()
-            .UseAppAmbit("9973a986-eb14-4aa2-965e-3880a5d354d2");
+            .UseAppAmbit("a8fcc5ca-e5c9-43e8-831a-26ca172cf3fd");
         
         return builder.Build();
     }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🛠️ Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📚 Documentation Update

## Description

This feature sends 30 errors, one every day, starting 30 days ago and ending with the current date.
This is done without internet to prevent it from being sent and to test the offline mode. These are stored in the database and are sent later when the internet connection is restored.

## Related Tickets & Documents

- [ID-976](https://app.asana.com/1/1203353714760101/project/1204450899416459/task/1210177970457034?focus=true)
- Closes #976

## QA Instructions, Screenshots, Recordings

1. Start the testing app without internet
2. Press the "Generate the last 30 daily errors" button
3. Wait for the errors to finish generating and saving them to the database.
4. Turn on the internet

## Added/updated tests?

- [ ] ✅ Yes
- [x] ❌ No, and this is why: tests were carried out on a physical Android device and with the help of the dashboard.
- [ ] 🤔 I need help with writing tests

## Are there any post deployment tasks we need to perform?
- [ ] 📝 Yes (please add details)
- [x] ❌ No
- [ ] ❓ I don't know

## Results of tests
<img width="368" alt="image" src="https://github.com/user-attachments/assets/c24ea4b1-bcd7-479f-957d-09de72862751" />

<img width="613" alt="image" src="https://github.com/user-attachments/assets/34221345-ea6c-4105-9a70-bafa471d8bac" />

## [optional] What gif best describes this PR or how it makes you feel?
![Alt Text](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExZDdocnJ2N3M0Mm1lcDE1b20zNDdnMmd4a3ozM25md2h6ZnIybG44NCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/pOZhmE42D1WrCWATLK/giphy.gif)
```
