### PR TITLE
ID-1011 - feature - Process and send sessions in batches to the endpoint

### DIFF
--- a/AppAmbitMaui/Core.cs
+++ b/AppAmbitMaui/Core.cs
@@ -73,6 +73,7 @@ public static class Core
 
         await Crashes.SendBatchLogs();
         await Analytics.SendBatchEvents();
+        await SessionManager.SendBatchSessions();
     }
 
     private static async Task OnStart(string appKey)
@@ -86,6 +87,7 @@ public static class Core
 
         await Crashes.SendBatchLogs();
         await Analytics.SendBatchEvents();
+        await SessionManager.SendBatchSessions();
     }
 
     private static async Task OnResume()

--- a/AppAmbitMaui/Models/Analytics/SessionBatch.cs
+++ b/AppAmbitMaui/Models/Analytics/SessionBatch.cs
@@ -1,0 +1,19 @@
+using System;
+using Newtonsoft.Json;
+
+namespace AppAmbit.Models.Analytics;
+
+public class SessionsPayload
+{
+    [JsonProperty("sessions")]
+    public List<SessionBatch> Sessions { get; set; }
+}
+
+public class SessionBatch
+{
+    [JsonProperty("started_at")]
+    public DateTime? StartedAt { get; set; }
+
+    [JsonProperty("ended_at")]
+    public DateTime? EndedAt { get; set; }
+}

--- a/AppAmbitMaui/Services/Endpoints/SessionBatchEndpoint.cs
+++ b/AppAmbitMaui/Services/Endpoints/SessionBatchEndpoint.cs
@@ -1,0 +1,16 @@
+
+using AppAmbit.Models.Analytics;
+using AppAmbit.Services.Endpoints.Base;
+using AppAmbit.Services.Interfaces;
+
+namespace AppAmbit.Services.Endpoints;
+
+internal class SessionBatchEndpoint : BaseEndpoint, IEndpoint
+{
+    public SessionBatchEndpoint(SessionsPayload sessionBatch)
+    {
+        Url = "/session/batch";
+        Method = HttpMethodEnum.Post;
+        Payload = sessionBatch;
+    }
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🛠️ Refactor
- [X] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📚 Documentation Update

## Description
This PR introduces a new functionality for sending sessions saved in the OfflineSessions file. Sessions are sent to the API in batches of 100. Each time the application starts, and internet connectivity is restored, the system checks if there are any saved sessions and sends them accordingly.


## Related Tickets & Documents
Closes: [ID-1011](https://app.asana.com/1/1203353714760101/project/1204450899416459/task/1210268003743475)

## QA Instructions, Screenshots, Recordings

*Please follow these instructions to test:*

* Install the app, disable internet, open and close the app to accumulate sessions.
* Re-enable internet and open the app again.
* Verify that sessions are sent in batches.
* Check the dashboard for the number of sessions.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] ✅ Yes
- [X] ❌ No, and this is why: Manual verification is needed to verify the batch submission of sessions.
- [ ] 🤔 I need help with writing tests

## Are there any post deployment tasks we need to perform?
- [ ] 📝 Yes (please add details)
- [X] ❌ No
- [ ] ❓ I don't know

## What gif best describes this PR or how it makes you feel?
![Sending sessions](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExemZqOTQ1NHpndmM3ZnB4b2pvdWNlNHIydThwcXN3N2tuMGp2NG5ieSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/yoJC2Olx0ekMy2nX7W/giphy.gif)
```
