### PR TITLE
ID-1048 - Bug Fix - Allow App Key updates by adding auto-increment primary key to AppSecrets

### DIFF
--- a/AppAmbitMaui/Models/App/AppSecrets.cs
+++ b/AppAmbitMaui/Models/App/AppSecrets.cs
@@ -4,7 +4,9 @@ namespace AppAmbit.Models.App;
 
 public class AppSecrets
 {
-    [PrimaryKey]
+    [PrimaryKey, AutoIncrement]
+    public int Id { get; set; }
+
     public string? AppId { get; set; }
     
     public string? DeviceId { get; set; } 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🛠️ Refactor
- [ ] ✨ Feature
- [X] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📚 Documentation Update

## Description

This PR fixes the issue related to updating the App Key. 
Previously, the `AppId` property in the `AppSecrets` table was set as the primary key, preventing changes to the App Key. 
To solve this, a new property was added and configured as the primary key with auto-increment enabled. 
This change allows updating the App Key without conflicts.
## Related Tickets & Documents

- [ID-1048](https://app.asana.com/1/1203353714760101/project/1204450899416459/task/1210443538809301)
- Closes #ID-1048

## QA Instructions, Screenshots, Recordings
Follow these steps to verify the fix:

Follow these steps to verify the fix:

1. Create **two applications** and generate an **App Key** for each one.
2. Install and run the app with the **first App Key**.
3. Create a few **events** and **logs**.
4. Close the app.
5. Launch the app and configure it with the **second App Key**.
7. Verify in the dashboard:
   - The first set of events/logs should appear under the **first application**.
   - The second set of events/logs should appear under the **second application**.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] ✅ Yes
- [X] ❌ No, and this is why:  Schema changes typically rely on integration testing; manual verification is sufficient in this case.
  have not been included_
- [ ] 🤔 I need help with writing tests

## Are there any post deployment tasks we need to perform?
- [ ] 📝 Yes (please add details)
- [X] ❌ No
- [ ] ❓ I don't know

##What gif best describes this PR or how it makes you feel?
![Alt Text](https://media.giphy.com/media/8fen5LSZcHQ5O/giphy.gif)
```
