### PR TITLE
ID-1057: Bug Fix - Manual mode is enabled for CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,10 +1,7 @@
 name: CI
 
 on:
-  push:
-    branches: [ develop ]
-  pull_request:
-    branches: [ develop ]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🛠️ Refactor
- [ ] ✨ Feature
- [X] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📚 Documentation Update

## Description
This PR modifies the **CI workflow** configuration:

- The automatic trigger on merge to `develop` has been **removed**.
- The workflow is now configured to be triggered **manually** via `workflow_dispatch` for any branch.
- This allows better control over CI executions, preventing unnecessary runs on every merge and enabling on-demand validation.


## Related Tickets & Documents
- [ID-1057](https://app.asana.com/1/1203353714760101/project/1204450899416459/task/1210528660140077)
- Closes #1057

## QA Instructions, Screenshots, Recordings

To verify this change:

1. Merge this branch into `develop` (this is required because `workflow_dispatch` must be present in the default branch).
2. After merging:
   - Go to the **Actions** tab in GitHub.
   - Locate the **CI** workflow.
   - Confirm that it can now be triggered manually for any branch using the **"Run workflow"** button.
   - Ensure that it does **not** trigger automatically on merge.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] ✅ Yes
- [X] ❌ No, and this is why: This change only affects CI/CD workflow triggers.
- [ ] 🤔 I need help with writing tests

## Are there any post deployment tasks we need to perform?
- [ ] 📝 Yes (please add details)
- [X] ❌ No
- [ ] ❓ I don't know
```
