### PR TITLE
ID-1574 - Feature: Added the cms

### DIFF
--- a/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia.Android/MainActivity.cs
+++ b/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia.Android/MainActivity.cs
@@ -18,7 +18,7 @@ public class MainActivity : AvaloniaMainActivity<App>
 {
     protected override AppBuilder CustomizeAppBuilder(AppBuilder builder)
     {
-        AppAmbitSdk.Start("581a777b-4c6f-4290-93db-834c08c97e37");
+        AppAmbitSdk.Start("<YOUR_APPKEY>");
         PushNotifications.Start(this);
         
         return base.CustomizeAppBuilder(builder);

--- a/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia.Android/MainActivity.cs
+++ b/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia.Android/MainActivity.cs
@@ -18,7 +18,7 @@ public class MainActivity : AvaloniaMainActivity<App>
 {
     protected override AppBuilder CustomizeAppBuilder(AppBuilder builder)
     {
-        AppAmbitSdk.Start("<YOUR_APPKEY>");
+        AppAmbitSdk.Start("581a777b-4c6f-4290-93db-834c08c97e37");
         PushNotifications.Start(this);
         
         return base.CustomizeAppBuilder(builder);

--- a/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Models/CmsExampleModel.cs
+++ b/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Models/CmsExampleModel.cs
@@ -1,3 +1,4 @@
+using Avalonia.Media.Imaging;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 
@@ -9,7 +10,7 @@ public class CmsExampleModel
     public decimal Price { get; set; }
 
     [JsonProperty("category")]
-    public string? Category { get; set; }
+    public List<string>? Category { get; set; }
 
     [JsonProperty("in_stock")]
     public bool InStock { get; set; }
@@ -28,6 +29,11 @@ public class CmsExampleModel
 
     [JsonProperty("product_image")]
     public string? ProductImage { get; set; }
+
+    [JsonProperty("product_image_url")]
+    public string? ProductImageUrl { get; set; }
+
+    public Bitmap? ProductBitmap { get; set; }
 
     [JsonProperty("support_email")]
     public string? SupportEmail { get; set; }

--- a/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Models/CmsExampleModel.cs
+++ b/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Models/CmsExampleModel.cs
@@ -1,0 +1,49 @@
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace AppAmbitTestingAppAvalonia.Models;
+
+public class CmsExampleModel
+{
+    [JsonProperty("price")]
+    public decimal Price { get; set; }
+
+    [JsonProperty("category")]
+    public string? Category { get; set; }
+
+    [JsonProperty("in_stock")]
+    public bool InStock { get; set; }
+
+    [JsonProperty("item_sku")]
+    public string? ItemSku { get; set; }
+
+    [JsonProperty("entry_date")]
+    public string? EntryDate { get; set; }
+
+    [JsonProperty("description")]
+    public string? Description { get; set; }
+
+    [JsonProperty("product_name")]
+    public string? ProductName { get; set; }
+
+    [JsonProperty("product_image")]
+    public string? ProductImage { get; set; }
+
+    [JsonProperty("support_email")]
+    public string? SupportEmail { get; set; }
+
+    [JsonProperty("technical_specs")]
+    public Dictionary<string, string>? TechnicalSpecs { get; set; }
+
+    [JsonProperty("id")]
+    public string? Id { get; set; }
+
+    [JsonProperty("published_at")]
+    public DateTimeOffset PublishedAt { get; set; }
+
+    [JsonProperty("created_at")]
+    public DateTimeOffset CreatedAt { get; set; }
+
+    [JsonProperty("updated_at")]
+    public DateTimeOffset UpdatedAt { get; set; }
+}

--- a/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Utils/ImageUtils.cs
+++ b/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Utils/ImageUtils.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using AppAmbitTestingAppAvalonia.Models;
+using Avalonia.Media.Imaging;
+
+namespace AppAmbitTestingAppAvalonia.Utils;
+
+internal static class ImageUtils
+{
+    private static readonly HttpClient _http = new();
+
+    /// <summary>
+    /// Downloads and decodes images for all items in parallel, populating
+    /// <see cref="CmsExampleModel.ProductBitmap"/>. Items without a URL are skipped.
+    /// </summary>
+    internal static async Task LoadAsync(IEnumerable<CmsExampleModel> items)
+    {
+        var tasks = items
+            .Where(i => !string.IsNullOrWhiteSpace(i.ProductImageUrl))
+            .Select(async item =>
+            {
+                try
+                {
+                    var bytes = await _http.GetByteArrayAsync(item.ProductImageUrl!);
+                    using var ms = new MemoryStream(bytes);
+                    item.ProductBitmap = new Bitmap(ms);
+                }
+                catch { }
+            });
+
+        await Task.WhenAll(tasks);
+    }
+}

--- a/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Views/CmsView.axaml
+++ b/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Views/CmsView.axaml
@@ -1,0 +1,148 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:models="using:AppAmbitTestingAppAvalonia.Models"
+             xmlns:views="using:AppAmbitTestingAppAvalonia.Views"
+             mc:Ignorable="d" d:DesignWidth="420" d:DesignHeight="700"
+             x:Class="AppAmbitTestingAppAvalonia.Views.CmsView">
+
+  <UserControl.Resources>
+    <views:BooleanToStockColorConverter x:Key="StockColorConverter" />
+    <views:BooleanToStockLabelConverter x:Key="StockLabelConverter" />
+  </UserControl.Resources>
+
+  <Grid RowDefinitions="Auto,Auto,Auto,*">
+
+    <!-- Header -->
+    <TextBlock Grid.Row="0"
+               Text="CMS"
+               FontSize="18"
+               FontWeight="Bold"
+               Margin="12,16,12,8" />
+
+    <!-- Search row -->
+    <Grid Grid.Row="1" ColumnDefinitions="*,Auto" Margin="12,0,12,8">
+      <TextBox x:Name="SearchBox"
+               Grid.Column="0"
+               Watermark="Search..."
+               Margin="0,0,8,0"
+               VerticalAlignment="Center" />
+      <Button x:Name="BtnSearch"
+              Grid.Column="1"
+              Content="Search"
+              Click="OnSearchClicked"
+              MinWidth="90" />
+    </Grid>
+
+    <!-- Filter row -->
+    <Grid Grid.Row="2" ColumnDefinitions="*,Auto" Margin="12,0,12,8">
+      <ComboBox x:Name="FilterPicker"
+                Grid.Column="0"
+                Margin="0,0,8,0"
+                HorizontalAlignment="Stretch"
+                PlaceholderText="Select a filter..." />
+      <Button x:Name="BtnApplyFilter"
+              Grid.Column="1"
+              Content="Apply"
+              Click="OnApplyFilterClicked"
+              MinWidth="90" />
+    </Grid>
+
+    <!-- Results area -->
+    <Grid Grid.Row="3" RowDefinitions="Auto,Auto,*">
+
+      <!-- Load all button -->
+      <Button Grid.Row="0"
+              x:Name="BtnFetchAll"
+              Content="Fetch All"
+              HorizontalAlignment="Stretch"
+              Margin="12,0,12,8"
+              Click="OnFetchAllClicked" />
+
+      <!-- Loading indicator -->
+      <ProgressBar Grid.Row="1"
+                   x:Name="LoadingBar"
+                   IsIndeterminate="True"
+                   IsVisible="False"
+                   Margin="12,0,12,4"
+                   Height="3" />
+
+      <!-- Items list -->
+      <ScrollViewer Grid.Row="2">
+        <StackPanel Margin="12,0,12,12" Spacing="8">
+
+          <!-- Empty state label -->
+          <TextBlock x:Name="EmptyLabel"
+                     Text="No items found. Cache may be empty — try again in a few seconds."
+                     IsVisible="False"
+                     TextWrapping="Wrap"
+                     Foreground="#6B7280"
+                     FontSize="14"
+                     Margin="0,8,0,0" />
+
+          <!-- Results -->
+          <ItemsControl x:Name="ResultsList">
+            <ItemsControl.ItemTemplate>
+              <DataTemplate x:DataType="models:CmsExampleModel">
+                <Border Background="White"
+                        BorderBrush="#E5E7EB"
+                        BorderThickness="1"
+                        CornerRadius="10"
+                        Padding="14"
+                        Margin="0,0,0,4">
+                  <Grid RowDefinitions="Auto,Auto,Auto">
+
+                    <!-- Product name + InStock badge -->
+                    <Grid Grid.Row="0" ColumnDefinitions="*,Auto">
+                      <TextBlock Grid.Column="0"
+                                 Text="{Binding ProductName}"
+                                 FontWeight="SemiBold"
+                                 FontSize="15"
+                                 TextWrapping="Wrap" />
+                      <Border Grid.Column="1"
+                              Background="{Binding InStock, Converter={StaticResource StockColorConverter}}"
+                              CornerRadius="6"
+                              Padding="8,3"
+                              VerticalAlignment="Center"
+                              Margin="8,0,0,0">
+                        <TextBlock Text="{Binding InStock, Converter={StaticResource StockLabelConverter}}"
+                                   Foreground="White"
+                                   FontSize="11"
+                                   FontWeight="Bold" />
+                      </Border>
+                    </Grid>
+
+                    <!-- SKU + Price -->
+                    <StackPanel Grid.Row="1"
+                                Orientation="Horizontal"
+                                Spacing="12"
+                                Margin="0,6,0,0">
+                      <TextBlock Text="{Binding ItemSku}"
+                                 Foreground="#6B7280"
+                                 FontSize="13" />
+                      <TextBlock Text="{Binding Price, StringFormat='${0:N2}'}"
+                                 Foreground="#6B21A8"
+                                 FontWeight="Bold"
+                                 FontSize="14" />
+                    </StackPanel>
+
+                    <!-- Description -->
+                    <TextBlock Grid.Row="2"
+                               Text="{Binding Description}"
+                               TextWrapping="Wrap"
+                               Foreground="#374151"
+                               FontSize="12"
+                               Margin="0,4,0,0" />
+
+                  </Grid>
+                </Border>
+              </DataTemplate>
+            </ItemsControl.ItemTemplate>
+          </ItemsControl>
+
+        </StackPanel>
+      </ScrollViewer>
+    </Grid>
+  </Grid>
+</UserControl>

--- a/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Views/CmsView.axaml
+++ b/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Views/CmsView.axaml
@@ -10,33 +10,21 @@
   <UserControl.Resources>
     <views:BooleanToStockColorConverter x:Key="StockColorConverter" />
     <views:BooleanToStockLabelConverter x:Key="StockLabelConverter" />
+    <views:ListToStringConverter x:Key="ListToStringConverter" />
   </UserControl.Resources>
 
   <Grid RowDefinitions="Auto,Auto,Auto,*">
 
     <!-- Header -->
     <TextBlock Grid.Row="0"
-               Text="CMS"
-               FontSize="18"
+               Text="CMS Query Builder"
+               FontSize="20"
                FontWeight="Bold"
+               HorizontalAlignment="Center"
                Margin="12,16,12,8" />
 
-    <!-- Search row -->
+    <!-- Filter row (first, like MAUI) -->
     <Grid Grid.Row="1" ColumnDefinitions="*,Auto" Margin="12,0,12,8">
-      <TextBox x:Name="SearchBox"
-               Grid.Column="0"
-               Watermark="Search..."
-               Margin="0,0,8,0"
-               VerticalAlignment="Center" />
-      <Button x:Name="BtnSearch"
-              Grid.Column="1"
-              Content="Search"
-              Click="OnSearchClicked"
-              MinWidth="90" />
-    </Grid>
-
-    <!-- Filter row -->
-    <Grid Grid.Row="2" ColumnDefinitions="*,Auto" Margin="12,0,12,8">
       <ComboBox x:Name="FilterPicker"
                 Grid.Column="0"
                 Margin="0,0,8,0"
@@ -49,13 +37,27 @@
               MinWidth="90" />
     </Grid>
 
+    <!-- Search row -->
+    <Grid Grid.Row="2" ColumnDefinitions="*,Auto" Margin="12,0,12,8">
+      <TextBox x:Name="SearchBox"
+               Grid.Column="0"
+               Watermark="Search term..."
+               Margin="0,0,8,0"
+               VerticalAlignment="Center" />
+      <Button x:Name="BtnSearch"
+              Grid.Column="1"
+              Content="Search"
+              Click="OnSearchClicked"
+              MinWidth="90" />
+    </Grid>
+
     <!-- Results area -->
     <Grid Grid.Row="3" RowDefinitions="Auto,Auto,*">
 
-      <!-- Load all button -->
+      <!-- Get All List button -->
       <Button Grid.Row="0"
               x:Name="BtnFetchAll"
-              Content="Fetch All"
+              Content="Get All List"
               HorizontalAlignment="Stretch"
               Margin="12,0,12,8"
               Click="OnFetchAllClicked" />
@@ -88,65 +90,93 @@
                 <Border Background="White"
                         BorderBrush="#E5E7EB"
                         BorderThickness="1"
-                        CornerRadius="10"
-                        Padding="14"
-                        Margin="0,0,0,4">
-                  <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto">
+                        CornerRadius="12"
+                        Padding="12"
+                        Margin="0,3,0,3">
+                  <Grid ColumnDefinitions="80,*" ColumnSpacing="14">
 
-                    <!-- Image placeholder (left, spanning all rows) -->
-                    <Border Grid.Column="0" Grid.RowSpan="3"
-                            Width="72" Height="72"
-                            Background="#F3F4F6"
+                    <!-- Image (80x80, matching MAUI) -->
+                    <Border Grid.Column="0"
+                            Width="80" Height="80"
+                            Background="#ECEFF1"
                             CornerRadius="8"
                             ClipToBounds="True"
-                            Margin="0,0,12,0"
                             VerticalAlignment="Top">
                       <Image Source="{Binding ProductBitmap}"
                              Stretch="UniformToFill" />
                     </Border>
 
-                    <!-- Product name + InStock badge -->
-                    <Grid Grid.Column="1" Grid.Row="0" ColumnDefinitions="*,Auto">
-                      <TextBlock Grid.Column="0"
-                                 Text="{Binding ProductName}"
-                                 FontWeight="SemiBold"
-                                 FontSize="15"
-                                 TextWrapping="Wrap" />
-                      <Border Grid.Column="1"
-                              Background="{Binding InStock, Converter={StaticResource StockColorConverter}}"
-                              CornerRadius="6"
-                              Padding="8,3"
-                              VerticalAlignment="Center"
-                              Margin="8,0,0,0">
-                        <TextBlock Text="{Binding InStock, Converter={StaticResource StockLabelConverter}}"
-                                   Foreground="White"
+                    <StackPanel Grid.Column="1" Spacing="4">
+
+                      <!-- Header: Name + Category badge -->
+                      <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                        <TextBlock Grid.Column="0"
+                                   Text="{Binding ProductName}"
+                                   FontWeight="Bold"
+                                   FontSize="16"
+                                   TextTrimming="CharacterEllipsis"
+                                   VerticalAlignment="Center" />
+                        <TextBlock Grid.Column="1"
+                                   Text="{Binding Category, Converter={StaticResource ListToStringConverter}, StringFormat='🏷️ {0}'}"
+                                   Foreground="#1976D2"
+                                   FontWeight="Bold"
                                    FontSize="11"
-                                   FontWeight="Bold" />
-                      </Border>
-                    </Grid>
+                                   VerticalAlignment="Center" />
+                      </Grid>
 
-                    <!-- SKU + Price -->
-                    <StackPanel Grid.Column="1" Grid.Row="1"
-                                Orientation="Horizontal"
-                                Spacing="12"
-                                Margin="0,6,0,0">
-                      <TextBlock Text="{Binding ItemSku}"
-                                 Foreground="#6B7280"
-                                 FontSize="13" />
-                      <TextBlock Text="{Binding Price, StringFormat='${0:N2}'}"
-                                 Foreground="#6B21A8"
-                                 FontWeight="Bold"
-                                 FontSize="14" />
+                      <!-- Description -->
+                      <TextBlock Text="{Binding Description}"
+                                 Foreground="#757575"
+                                 FontSize="13"
+                                 MaxLines="2"
+                                 TextWrapping="Wrap"
+                                 TextTrimming="CharacterEllipsis" />
+
+                      <!-- Meta: SKU + Price + Stock -->
+                      <WrapPanel Orientation="Horizontal">
+                        <TextBlock Text="{Binding ItemSku}"
+                                   Foreground="#9E9E9E"
+                                   FontSize="12"
+                                   Margin="0,0,12,0" />
+                        <TextBlock Text="{Binding Price, StringFormat='${0:N2}'}"
+                                   Foreground="#4CAF50"
+                                   FontWeight="Bold"
+                                   FontSize="13"
+                                   Margin="0,0,12,0" />
+                        <TextBlock Text="{Binding InStock, Converter={StaticResource StockLabelConverter}}"
+                                   Foreground="#607D8B"
+                                   FontSize="12" />
+                      </WrapPanel>
+
+                      <!-- Support Email -->
+                      <TextBlock Text="{Binding SupportEmail, StringFormat='📧 {0}'}"
+                                 Foreground="#757575"
+                                 FontSize="11"
+                                 TextTrimming="CharacterEllipsis" />
+
+                      <!-- Separator -->
+                      <Border Height="1" Background="#EEEEEE" Margin="0,4" />
+
+                      <!-- ID -->
+                      <TextBlock Text="{Binding Id, StringFormat='ID: {0}'}"
+                                 Foreground="#BDBDBD"
+                                 FontSize="10"
+                                 TextTrimming="CharacterEllipsis" />
+
+                      <!-- Dates Grid -->
+                      <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="8" RowSpacing="2">
+                        <TextBlock Grid.Row="0" Grid.Column="0"
+                                   Text="{Binding CreatedAt, StringFormat='Cr: {0:dd/MM/yyyy}'}"
+                                   Foreground="#9E9E9E" FontSize="10" />
+                        <TextBlock Grid.Row="0" Grid.Column="1"
+                                   Text="{Binding PublishedAt, StringFormat='Pub: {0:dd/MM/yyyy}'}"
+                                   Foreground="#9E9E9E" FontSize="10" />
+                        <TextBlock Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
+                                   Text="{Binding UpdatedAt, StringFormat='Upd: {0:dd/MM/yyyy}'}"
+                                   Foreground="#9E9E9E" FontSize="10" />
+                      </Grid>
+
                     </StackPanel>
-
-                    <!-- Description -->
-                    <TextBlock Grid.Column="1" Grid.Row="2"
-                               Text="{Binding Description}"
-                               TextWrapping="Wrap"
-                               Foreground="#374151"
-                               FontSize="12"
-                               Margin="0,4,0,0" />
-
                   </Grid>
                 </Border>
               </DataTemplate>

--- a/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Views/CmsView.axaml
+++ b/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Views/CmsView.axaml
@@ -91,10 +91,22 @@
                         CornerRadius="10"
                         Padding="14"
                         Margin="0,0,0,4">
-                  <Grid RowDefinitions="Auto,Auto,Auto">
+                  <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto">
+
+                    <!-- Image placeholder (left, spanning all rows) -->
+                    <Border Grid.Column="0" Grid.RowSpan="3"
+                            Width="72" Height="72"
+                            Background="#F3F4F6"
+                            CornerRadius="8"
+                            ClipToBounds="True"
+                            Margin="0,0,12,0"
+                            VerticalAlignment="Top">
+                      <Image Source="{Binding ProductBitmap}"
+                             Stretch="UniformToFill" />
+                    </Border>
 
                     <!-- Product name + InStock badge -->
-                    <Grid Grid.Row="0" ColumnDefinitions="*,Auto">
+                    <Grid Grid.Column="1" Grid.Row="0" ColumnDefinitions="*,Auto">
                       <TextBlock Grid.Column="0"
                                  Text="{Binding ProductName}"
                                  FontWeight="SemiBold"
@@ -114,7 +126,7 @@
                     </Grid>
 
                     <!-- SKU + Price -->
-                    <StackPanel Grid.Row="1"
+                    <StackPanel Grid.Column="1" Grid.Row="1"
                                 Orientation="Horizontal"
                                 Spacing="12"
                                 Margin="0,6,0,0">
@@ -128,7 +140,7 @@
                     </StackPanel>
 
                     <!-- Description -->
-                    <TextBlock Grid.Row="2"
+                    <TextBlock Grid.Column="1" Grid.Row="2"
                                Text="{Binding Description}"
                                TextWrapping="Wrap"
                                Foreground="#374151"

--- a/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Views/CmsView.axaml.cs
+++ b/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Views/CmsView.axaml.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AppAmbitAvalonia;
+using AppAmbitTestingAppAvalonia.Models;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using Avalonia.Threading;
+
+namespace AppAmbitTestingAppAvalonia.Views;
+
+public partial class CmsView : UserControl
+{
+    private const string Collection = "tech_inventory";
+
+    private readonly List<(string Label, Func<AppAmbit.ICmsQueryBuilder<CmsExampleModel>> Build)> _filters;
+
+    public CmsView()
+    {
+        InitializeComponent();
+
+        _filters = new()
+        {
+            ("Equals: item_sku = TEC-02",
+                () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).Equals("item_sku", "TEC-02")),
+            ("Not Equals: item_sku ≠ TEC-02",
+                () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).NotEquals("item_sku", "TEC-02")),
+            ("Boolean: in_stock = true",
+                () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).Equals("in_stock", "true")),
+            ("Contains: product_name contains 'Pro'",
+                () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).Contains("product_name", "Pro")),
+            ("Starts With: item_sku starts with 'TEC'",
+                () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).StartsWith("item_sku", "TEC")),
+            ("In List: [TEC-01, TEC-02]",
+                () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).InList("item_sku", new[] { "TEC-01", "TEC-02" })),
+            ("Not In List: [TEC-01, TEC-02]",
+                () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).NotInList("item_sku", new[] { "TEC-01", "TEC-02" })),
+            ("Greater Than: price > 500",
+                () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).GreaterThan("price", 500)),
+            ("Greater Or Equal: price >= 222",
+                () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).GreaterThanOrEqual("price", 222)),
+            ("Less Than: price < 500",
+                () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).LessThan("price", 500)),
+            ("Order By price ASC",
+                () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).OrderByAscending("price")),
+            ("Order By price DESC",
+                () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).OrderByDescending("price")),
+            ("Pagination: Page 1 — 1 per page",
+                () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).GetPage(1).GetPerPage(1)),
+            ("Pagination: Page 2 — 1 per page",
+                () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).GetPage(2).GetPerPage(1)),
+        };
+
+        FilterPicker.ItemsSource = _filters.Select(f => f.Label).ToList();
+    }
+
+    // ── Event handlers ──────────────────────────────────────────────────────────
+
+    private async void OnFetchAllClicked(object? sender, RoutedEventArgs e)
+    {
+        await LoadResults(AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection));
+    }
+
+    private async void OnApplyFilterClicked(object? sender, RoutedEventArgs e)
+    {
+        if (FilterPicker.SelectedIndex < 0)
+        {
+            await AlertWindow.ShowAlert("Please select a filter first.");
+            return;
+        }
+        await LoadResults(_filters[FilterPicker.SelectedIndex].Build());
+    }
+
+    private async void OnSearchClicked(object? sender, RoutedEventArgs e)
+    {
+        var term = SearchBox.Text?.Trim();
+        if (!string.IsNullOrWhiteSpace(term))
+        {
+            await LoadResults(AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).Search(term));
+        }
+        else
+        {
+            await LoadResults(AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection));
+        }
+    }
+
+    // ── Core logic ───────────────────────────────────────────────────────────────
+
+    private async Task LoadResults(AppAmbit.ICmsQueryBuilder<CmsExampleModel> query)
+    {
+        SetLoading(true);
+
+        try
+        {
+            var items = await query.GetListAsync();
+
+            Dispatcher.UIThread.Post(() =>
+            {
+                ResultsList.ItemsSource = items;
+                EmptyLabel.IsVisible = items.Count == 0;
+            });
+        }
+        catch (Exception ex)
+        {
+            await AlertWindow.ShowAlert($"Error loading CMS data: {ex.Message}");
+        }
+        finally
+        {
+            SetLoading(false);
+        }
+    }
+
+    private void SetLoading(bool loading)
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            LoadingBar.IsVisible = loading;
+            BtnFetchAll.IsEnabled = !loading;
+            BtnApplyFilter.IsEnabled = !loading;
+            BtnSearch.IsEnabled = !loading;
+        });
+    }
+}
+
+// ── Value converters ─────────────────────────────────────────────────────────────
+
+/// <summary>Converts bool InStock → badge background color.</summary>
+public sealed class BooleanToStockColorConverter : Avalonia.Data.Converters.IValueConverter
+{
+    public static readonly BooleanToStockColorConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+        => value is true
+            ? new SolidColorBrush(Color.Parse("#16A34A"))  // green-600
+            : new SolidColorBrush(Color.Parse("#DC2626")); // red-600
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
+/// <summary>Converts bool InStock → "In Stock" / "Out of Stock" label.</summary>
+public sealed class BooleanToStockLabelConverter : Avalonia.Data.Converters.IValueConverter
+{
+    public static readonly BooleanToStockLabelConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+        => value is true ? "In Stock" : "Out of Stock";
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Views/CmsView.axaml.cs
+++ b/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Views/CmsView.axaml.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using AppAmbitAvalonia;
 using AppAmbitTestingAppAvalonia.Models;
+using AppAmbitTestingAppAvalonia.Utils;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Media;
@@ -95,6 +96,7 @@ public partial class CmsView : UserControl
         try
         {
             var items = await query.GetListAsync();
+            await ImageUtils.LoadAsync(items);
 
             Dispatcher.UIThread.Post(() =>
             {

--- a/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Views/CmsView.axaml.cs
+++ b/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Views/CmsView.axaml.cs
@@ -24,34 +24,53 @@ public partial class CmsView : UserControl
 
         _filters = new()
         {
+            // Equality
             ("Equals: item_sku = TEC-02",
                 () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).Equals("item_sku", "TEC-02")),
             ("Not Equals: item_sku ≠ TEC-02",
                 () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).NotEquals("item_sku", "TEC-02")),
+            ("In List: category = Cat 1",
+                () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).InList("category", new[] { "Cat 1" })),
             ("Boolean: in_stock = true",
                 () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).Equals("in_stock", "true")),
+
+            // Text matching
             ("Contains: product_name contains 'Pro'",
                 () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).Contains("product_name", "Pro")),
             ("Starts With: item_sku starts with 'TEC'",
                 () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).StartsWith("item_sku", "TEC")),
-            ("In List: [TEC-01, TEC-02]",
+
+            // List membership
+            ("In List: item_sku in [TEC-01, TEC-02]",
                 () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).InList("item_sku", new[] { "TEC-01", "TEC-02" })),
-            ("Not In List: [TEC-01, TEC-02]",
+            ("Not In List: item_sku not in [TEC-01, TEC-02]",
                 () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).NotInList("item_sku", new[] { "TEC-01", "TEC-02" })),
+
+            // Numeric comparisons
             ("Greater Than: price > 500",
                 () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).GreaterThan("price", 500)),
-            ("Greater Or Equal: price >= 222",
-                () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).GreaterThanOrEqual("price", 222)),
+            ("Greater Or Equal: price >= 500",
+                () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).GreaterThanOrEqual("price", 500)),
             ("Less Than: price < 500",
                 () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).LessThan("price", 500)),
+            ("Less Or Equal: price <= 500",
+                () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).LessThanOrEqual("price", 500)),
+
+            // Sorting
+            ("Order By product_name ASC",
+                () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).OrderByAscending("product_name")),
+            ("Order By product_name DESC",
+                () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).OrderByDescending("product_name")),
             ("Order By price ASC",
                 () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).OrderByAscending("price")),
             ("Order By price DESC",
                 () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).OrderByDescending("price")),
-            ("Pagination: Page 1 — 1 per page",
-                () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).GetPage(1).GetPerPage(1)),
-            ("Pagination: Page 2 — 1 per page",
-                () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).GetPage(2).GetPerPage(1)),
+
+            // Pagination
+            ("Pagination: Page 1, 2 per page",
+                () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).GetPage(1).GetPerPage(2)),
+            ("Pagination: Page 2, 2 per page",
+                () => AppAmbitAvalonia.Cms.Content<CmsExampleModel>(Collection).GetPage(2).GetPerPage(2)),
         };
 
         FilterPicker.ItemsSource = _filters.Select(f => f.Label).ToList();
@@ -149,6 +168,18 @@ public sealed class BooleanToStockLabelConverter : Avalonia.Data.Converters.IVal
 
     public object? Convert(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
         => value is true ? "In Stock" : "Out of Stock";
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
+/// <summary>Converts List&lt;string&gt; → comma-separated string.</summary>
+public sealed class ListToStringConverter : Avalonia.Data.Converters.IValueConverter
+{
+    public static readonly ListToStringConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
+        => value is IEnumerable<string> list ? string.Join(", ", list) : string.Empty;
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
         => throw new NotSupportedException();

--- a/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Views/MainView.axaml
+++ b/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Views/MainView.axaml
@@ -3,6 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:AppAmbitTestingAppAvalonia.ViewModels"
+             xmlns:views="using:AppAmbitTestingAppAvalonia.Views"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="AppAmbitTestingAppAvalonia.Views.MainView"
              x:DataType="vm:MainViewModel">
@@ -94,6 +95,11 @@
       </ScrollViewer>
 
 
+      <!-- CMS view -->
+      <ScrollViewer Name="CmsPanel" IsVisible="False">
+        <views:CmsView />
+      </ScrollViewer>
+
     </Grid>
     <Border Grid.Row="1" Background="Transparent" Padding="16">
       <Border Name="BottomNav" Background="{StaticResource NavBackgroundBrush}" CornerRadius="28" Padding="8" HorizontalAlignment="Center" Width="420">
@@ -108,6 +114,10 @@
 
           <Button Classes="bottom-nav-item" Name="NavRemoteConfig" Click="OnNavRemoteConfigClicked">
             <TextBlock Text="Remote Config" FontSize="14" HorizontalAlignment="Center" VerticalAlignment="Center" />
+          </Button>
+
+          <Button Classes="bottom-nav-item" Name="NavCms" Click="OnNavCmsClicked">
+            <TextBlock Text="CMS" FontSize="14" HorizontalAlignment="Center" VerticalAlignment="Center" />
           </Button>
         </StackPanel>
       </Border>

--- a/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Views/MainView.axaml.cs
+++ b/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Views/MainView.axaml.cs
@@ -64,8 +64,17 @@ public partial class MainView : UserControl
         CrashesPanel.IsVisible = false;
         AnalyticsPanel.IsVisible = false;
         RemoteConfigPanel.IsVisible = true;
-        
+        CmsPanel.IsVisible = false;
+
         UpdateRemoteConfigUI();
+    }
+
+    private void OnNavCmsClicked(object? sender, RoutedEventArgs e)
+    {
+        CrashesPanel.IsVisible = false;
+        AnalyticsPanel.IsVisible = false;
+        RemoteConfigPanel.IsVisible = false;
+        CmsPanel.IsVisible = true;
     }
 
     private void UpdateRemoteConfigUI()

--- a/samples/AppAmbit.App.Maui.Native.Android/Adapters/CmsAdapter.cs
+++ b/samples/AppAmbit.App.Maui.Native.Android/Adapters/CmsAdapter.cs
@@ -4,6 +4,7 @@ using Android.Views;
 using Android.Widget;
 using AndroidX.RecyclerView.Widget;
 using AppAmbitTestingAppAndroid.Models;
+using AppAmbitTestingAppAndroid.Utils;
 
 namespace AppAmbitTestingAppAndroid.Adapters;
 
@@ -39,6 +40,7 @@ public class CmsAdapter : RecyclerView.Adapter
 
     private class CmsViewHolder : RecyclerView.ViewHolder
     {
+        private readonly ImageView _ivProduct;
         private readonly TextView _tvProductName;
         private readonly TextView _tvCategory;
         private readonly TextView _tvDescription;
@@ -56,6 +58,7 @@ public class CmsAdapter : RecyclerView.Adapter
             var ctx = itemView.Context!;
             int GetId(string name) => ctx.Resources!.GetIdentifier(name, "id", ctx.PackageName);
 
+            _ivProduct = itemView.FindViewById<ImageView>(GetId("iv_product"))!;
             _tvProductName = itemView.FindViewById<TextView>(GetId("tv_product_name"))!;
             _tvCategory = itemView.FindViewById<TextView>(GetId("tv_category"))!;
             _tvDescription = itemView.FindViewById<TextView>(GetId("tv_description"))!;
@@ -72,7 +75,7 @@ public class CmsAdapter : RecyclerView.Adapter
         public void Bind(CmsExampleModel item)
         {
             _tvProductName.Text = item.ProductName;
-            _tvCategory.Text = string.IsNullOrEmpty(item.Category) ? "" : $"🏷️ {item.Category}";
+            _tvCategory.Text = item.Category?.Count > 0 ? $"🏷️ {string.Join(", ", item.Category)}" : "";
             _tvDescription.Text = item.Description;
             _tvSku.Text = item.ItemSku;
             _tvPrice.Text = $"${item.Price:F2}";
@@ -82,6 +85,10 @@ public class CmsAdapter : RecyclerView.Adapter
             _tvCreatedAt.Text = $"Cr: {item.CreatedAt:dd/MM/yyyy}";
             _tvPublishedAt.Text = $"Pub: {item.PublishedAt:dd/MM/yyyy}";
             _tvUpdatedAt.Text = $"Upd: {item.UpdatedAt:dd/MM/yyyy}";
+
+            _ivProduct.SetImageDrawable(null);
+            if (!string.IsNullOrWhiteSpace(item.ProductImageUrl))
+                ImageUtils.LoadAsync(item.ProductImageUrl!, _ivProduct, item.Id ?? item.ProductImageUrl!);
         }
     }
 }

--- a/samples/AppAmbit.App.Maui.Native.Android/Adapters/CmsAdapter.cs
+++ b/samples/AppAmbit.App.Maui.Native.Android/Adapters/CmsAdapter.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using Android.Content;
+using Android.Views;
+using Android.Widget;
+using AndroidX.RecyclerView.Widget;
+using AppAmbitTestingAppAndroid.Models;
+
+namespace AppAmbitTestingAppAndroid.Adapters;
+
+public class CmsAdapter : RecyclerView.Adapter
+{
+    private readonly List<CmsExampleModel> _items = new();
+
+    public override int ItemCount => _items.Count;
+
+    public void UpdateData(IEnumerable<CmsExampleModel> newItems)
+    {
+        _items.Clear();
+        _items.AddRange(newItems);
+        NotifyDataSetChanged();
+    }
+
+    public override void OnBindViewHolder(RecyclerView.ViewHolder holder, int position)
+    {
+        if (holder is CmsViewHolder vh)
+        {
+            var item = _items[position];
+            vh.Bind(item);
+        }
+    }
+
+    public override RecyclerView.ViewHolder OnCreateViewHolder(ViewGroup parent, int viewType)
+    {
+        var ctx = parent.Context!;
+        int layoutId = ctx.Resources!.GetIdentifier("item_cms", "layout", ctx.PackageName);
+        var view = LayoutInflater.From(ctx)!.Inflate(layoutId, parent, false);
+        return new CmsViewHolder(view!);
+    }
+
+    private class CmsViewHolder : RecyclerView.ViewHolder
+    {
+        private readonly TextView _tvProductName;
+        private readonly TextView _tvCategory;
+        private readonly TextView _tvDescription;
+        private readonly TextView _tvSku;
+        private readonly TextView _tvPrice;
+        private readonly TextView _tvStock;
+        private readonly TextView _tvSupport;
+        private readonly TextView _tvId;
+        private readonly TextView _tvCreatedAt;
+        private readonly TextView _tvPublishedAt;
+        private readonly TextView _tvUpdatedAt;
+
+        public CmsViewHolder(View itemView) : base(itemView)
+        {
+            var ctx = itemView.Context!;
+            int GetId(string name) => ctx.Resources!.GetIdentifier(name, "id", ctx.PackageName);
+
+            _tvProductName = itemView.FindViewById<TextView>(GetId("tv_product_name"))!;
+            _tvCategory = itemView.FindViewById<TextView>(GetId("tv_category"))!;
+            _tvDescription = itemView.FindViewById<TextView>(GetId("tv_description"))!;
+            _tvSku = itemView.FindViewById<TextView>(GetId("tv_sku"))!;
+            _tvPrice = itemView.FindViewById<TextView>(GetId("tv_price"))!;
+            _tvStock = itemView.FindViewById<TextView>(GetId("tv_stock"))!;
+            _tvSupport = itemView.FindViewById<TextView>(GetId("tv_support"))!;
+            _tvId = itemView.FindViewById<TextView>(GetId("tv_id"))!;
+            _tvCreatedAt = itemView.FindViewById<TextView>(GetId("tv_created_at"))!;
+            _tvPublishedAt = itemView.FindViewById<TextView>(GetId("tv_published_at"))!;
+            _tvUpdatedAt = itemView.FindViewById<TextView>(GetId("tv_updated_at"))!;
+        }
+
+        public void Bind(CmsExampleModel item)
+        {
+            _tvProductName.Text = item.ProductName;
+            _tvCategory.Text = string.IsNullOrEmpty(item.Category) ? "" : $"🏷️ {item.Category}";
+            _tvDescription.Text = item.Description;
+            _tvSku.Text = item.ItemSku;
+            _tvPrice.Text = $"${item.Price:F2}";
+            _tvStock.Text = $"Stock: {item.InStock}";
+            _tvSupport.Text = $"📧 {item.SupportEmail}";
+            _tvId.Text = $"ID: {item.Id}";
+            _tvCreatedAt.Text = $"Cr: {item.CreatedAt:dd/MM/yyyy}";
+            _tvPublishedAt.Text = $"Pub: {item.PublishedAt:dd/MM/yyyy}";
+            _tvUpdatedAt.Text = $"Upd: {item.UpdatedAt:dd/MM/yyyy}";
+        }
+    }
+}

--- a/samples/AppAmbit.App.Maui.Native.Android/AppAmbit.App.Maui.Native.Android.csproj
+++ b/samples/AppAmbit.App.Maui.Native.Android/AppAmbit.App.Maui.Native.Android.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0-android</TargetFramework>
-    <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>24</SupportedOSPlatformVersion>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -16,5 +16,9 @@
   
   <ItemGroup>
     <GoogleServicesJson Include="google-services.json" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Xamarin.AndroidX.RecyclerView" Version="1.4.0.5" />
   </ItemGroup>
 </Project>

--- a/samples/AppAmbit.App.Maui.Native.Android/MainActivity.cs
+++ b/samples/AppAmbit.App.Maui.Native.Android/MainActivity.cs
@@ -5,10 +5,11 @@ using System.Threading.Tasks;
 using Android.App;
 using Android.Content;
 using Android.Views;
-using Android.OS;
 using Android.Widget;
 using AppAmbit.PushNotifications;
 using AppAmbitMaui;
+using AppAmbitTestingAppAndroid.Models;
+using AppAmbitTestingAppAndroid.Adapters;
 
 namespace AppAmbitTestingAppAndroid;
 
@@ -19,10 +20,14 @@ public class MainActivity : Activity
     View? _viewCrashes;
     View? _viewAnalytics;
     View? _viewRemoteConfig;
+    View? _viewCms;
     Button? _btnPushNotifications;
     bool _hasNotificationPermission;
     bool _notificationsEnabled;
     bool _isUpdatingPushButton;
+
+    // Filters for CMS
+    private List<(string Label, Func<AppAmbit.CmsQueryBuilder<CmsExampleModel>> Build)>? _cmsFilters;
 
     int L(string name) => Resources.GetIdentifier(name, "layout", PackageName);
     int I(string name) => Resources.GetIdentifier(name, "id", PackageName);
@@ -47,17 +52,21 @@ public class MainActivity : Activity
         _viewCrashes = inflater?.Inflate(L("fragment_crashes"), _container, false);
         _viewAnalytics = inflater?.Inflate(L("fragment_analytics"), _container, false);
         _viewRemoteConfig = inflater?.Inflate(L("fragment_remote_config"), _container, false);
+        _viewCms = inflater?.Inflate(L("fragment_cms"), _container, false);
 
         WireCrashesView(_viewCrashes!);
         WireAnalyticsView(_viewAnalytics!);
+        WireCmsView(_viewCms!);
         
         var btnCrashes = FindViewById<Button>(I("btn_nav_crashes"))!;
         var btnAnalytics = FindViewById<Button>(I("btn_nav_analytics"))!;
         var btnRemoteConfig = FindViewById<Button>(I("btn_nav_remote_config"))!;
+        var btnCms = FindViewById<Button>(I("btn_nav_cms"))!;
 
         btnCrashes.Click += (s, e) => ShowView(_viewCrashes!);
         btnAnalytics.Click += (s, e) => ShowView(_viewAnalytics!);
         btnRemoteConfig.Click += (s, e) => ShowRemoteConfigView(_viewRemoteConfig!);
+        btnCms.Click += (s, e) => ShowView(_viewCms!);
 
         ShowView(_viewCrashes!);
     }
@@ -357,5 +366,80 @@ public class MainActivity : Activity
     {
         ShowView(v);
         UpdateRemoteConfigUI(v);
+    }
+
+    void WireCmsView(View root)
+    {
+        T Find<T>(string id) where T : View => (T)root.FindViewById(I(id))!;
+        
+        var spinner = Find<Spinner>("spin_cms_filters");
+        var btnApply = Find<Button>("btn_cms_apply_filter");
+        var etSearch = Find<EditText>("et_cms_search");
+        var btnSearch = Find<Button>("btn_cms_search");
+        var btnGetAll = Find<Button>("btn_cms_get_all");
+        var recycler = Find<AndroidX.RecyclerView.Widget.RecyclerView>("recycler_cms");
+
+        var adapter = new CmsAdapter();
+        recycler.SetLayoutManager(new AndroidX.RecyclerView.Widget.LinearLayoutManager(this));
+        recycler.SetAdapter(adapter);
+
+        const string collection = "tech_inventory";
+
+        _cmsFilters = new()
+        {
+            ("Equals: item_sku = TEC-02", () => AppAmbit.Cms.For<CmsExampleModel>(collection).Equals("item_sku", "TEC-02")),
+            ("Not Equals: item_sku ≠ TEC-02", () => AppAmbit.Cms.For<CmsExampleModel>(collection).NotEquals("item_sku", "TEC-02")),
+            ("Contains: product_name contains 'Pro'", () => AppAmbit.Cms.For<CmsExampleModel>(collection).Contains("product_name", "Pro")),
+            ("Starts With: item_sku starts with 'TEC'", () => AppAmbit.Cms.For<CmsExampleModel>(collection).StartsWith("item_sku", "TEC")),
+            ("In List: [TEC-01, TEC-02]", () => AppAmbit.Cms.For<CmsExampleModel>(collection).InList("item_sku", new[] { "TEC-01", "TEC-02" })),
+            ("Greater Than: price > 500", () => AppAmbit.Cms.For<CmsExampleModel>(collection).GreaterThan("price", 500)),
+            ("Order By price DESC", () => AppAmbit.Cms.For<CmsExampleModel>(collection).OrderByDescending("price")),
+            ("Pagination: Page 1, 2 items", () => AppAmbit.Cms.For<CmsExampleModel>(collection).SetPage(1).SetPerPage(2)),
+            ("Pagination: Page 2, 2 items", () => AppAmbit.Cms.For<CmsExampleModel>(collection).SetPage(2).SetPerPage(2)),
+        };
+
+        var filterNames = _cmsFilters.Select(f => f.Label).ToList();
+        var arrayAdapter = new ArrayAdapter<string>(this, Android.Resource.Layout.SimpleSpinnerItem, filterNames);
+        arrayAdapter.SetDropDownViewResource(Android.Resource.Layout.SimpleSpinnerDropDownItem);
+        spinner.Adapter = arrayAdapter;
+
+        async Task LoadResults(AppAmbit.CmsQueryBuilder<CmsExampleModel> query)
+        {
+            try
+            {
+                var items = await query.GetListAsync();
+                RunOnUiThread(() => adapter.UpdateData(items));
+
+                if (items.Count == 0)
+                    ShowAlert("Info", "No entries found. Cache may be empty.");
+            }
+            catch (Exception ex)
+            {
+                ShowAlert("Error", ex.Message);
+            }
+        }
+
+        btnGetAll.Click += async (s, e) => 
+        {
+            await AppAmbit.Cms.Clear("sistema_de_gestion_de_propiedades_de_una_marinaclub_nautico");
+            await LoadResults(AppAmbit.Cms.For<CmsExampleModel>(collection));
+        };
+
+        btnApply.Click += async (s, e) =>
+        {
+            int selected = spinner.SelectedItemPosition;
+            if (selected >= 0 && selected < _cmsFilters.Count)
+            {
+                var query = _cmsFilters[selected].Build();
+                await LoadResults(query);
+            }
+        };
+
+        btnSearch.Click += async (s, e) =>
+        {
+            var term = etSearch.Text?.Trim();
+            if (!string.IsNullOrEmpty(term))
+                await LoadResults(AppAmbit.Cms.For<CmsExampleModel>(collection).Search(term));
+        };
     }
 }

--- a/samples/AppAmbit.App.Maui.Native.Android/MainActivity.cs
+++ b/samples/AppAmbit.App.Maui.Native.Android/MainActivity.cs
@@ -389,15 +389,35 @@ public class MainActivity : Activity
 
         _cmsFilters = new()
         {
+            // Equality
             ("Equals: item_sku = TEC-02", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).Equals("item_sku", "TEC-02")),
             ("Not Equals: item_sku ≠ TEC-02", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).NotEquals("item_sku", "TEC-02")),
+            ("In List: category = Cat 1", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).InList("category", new[] { "Cat 1" })),
+            ("Boolean: in_stock = true", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).Equals("in_stock", "true")),
+
+            // Text matching
             ("Contains: product_name contains 'Pro'", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).Contains("product_name", "Pro")),
             ("Starts With: item_sku starts with 'TEC'", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).StartsWith("item_sku", "TEC")),
-            ("In List: [TEC-01, TEC-02]", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).InList("item_sku", new[] { "TEC-01", "TEC-02" })),
+
+            // List membership
+            ("In List: item_sku in [TEC-01, TEC-02]", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).InList("item_sku", new[] { "TEC-01", "TEC-02" })),
+            ("Not In List: item_sku not in [TEC-01, TEC-02]", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).NotInList("item_sku", new[] { "TEC-01", "TEC-02" })),
+
+            // Numeric comparisons
             ("Greater Than: price > 500", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).GreaterThan("price", 500)),
+            ("Greater Or Equal: price >= 500", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).GreaterThanOrEqual("price", 500)),
+            ("Less Than: price < 500", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).LessThan("price", 500)),
+            ("Less Or Equal: price <= 500", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).LessThanOrEqual("price", 500)),
+
+            // Sorting
+            ("Order By product_name ASC", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).OrderByAscending("product_name")),
+            ("Order By product_name DESC", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).OrderByDescending("product_name")),
+            ("Order By price ASC", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).OrderByAscending("price")),
             ("Order By price DESC", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).OrderByDescending("price")),
-            ("Pagination: Page 1, 2 items", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).GetPage(1).GetPerPage(2)),
-            ("Pagination: Page 2, 2 items", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).GetPage(2).GetPerPage(2)),
+
+            // Pagination
+            ("Pagination: Page 1, 2 per page", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).GetPage(1).GetPerPage(2)),
+            ("Pagination: Page 2, 2 per page", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).GetPage(2).GetPerPage(2)),
         };
 
         var filterNames = _cmsFilters.Select(f => f.Label).ToList();
@@ -440,7 +460,6 @@ public class MainActivity : Activity
 
         btnGetAll.Click += async (s, e) => 
         {
-            await AppAmbit.Cms.ClearCache(collection);
             await LoadResults(AppAmbit.Cms.Content<CmsExampleModel>(collection));
         };
 

--- a/samples/AppAmbit.App.Maui.Native.Android/MainActivity.cs
+++ b/samples/AppAmbit.App.Maui.Native.Android/MainActivity.cs
@@ -27,7 +27,7 @@ public class MainActivity : Activity
     bool _isUpdatingPushButton;
 
     // Filters for CMS
-    private List<(string Label, Func<AppAmbit.CmsQueryBuilder<CmsExampleModel>> Build)>? _cmsFilters;
+    private List<(string Label, Func<AppAmbit.ICmsQueryBuilder<CmsExampleModel>> Build)>? _cmsFilters;
 
     int L(string name) => Resources.GetIdentifier(name, "layout", PackageName);
     int I(string name) => Resources.GetIdentifier(name, "id", PackageName);
@@ -394,8 +394,8 @@ public class MainActivity : Activity
             ("In List: [TEC-01, TEC-02]", () => AppAmbit.Cms.For<CmsExampleModel>(collection).InList("item_sku", new[] { "TEC-01", "TEC-02" })),
             ("Greater Than: price > 500", () => AppAmbit.Cms.For<CmsExampleModel>(collection).GreaterThan("price", 500)),
             ("Order By price DESC", () => AppAmbit.Cms.For<CmsExampleModel>(collection).OrderByDescending("price")),
-            ("Pagination: Page 1, 2 items", () => AppAmbit.Cms.For<CmsExampleModel>(collection).SetPage(1).SetPerPage(2)),
-            ("Pagination: Page 2, 2 items", () => AppAmbit.Cms.For<CmsExampleModel>(collection).SetPage(2).SetPerPage(2)),
+            ("Pagination: Page 1, 2 items", () => AppAmbit.Cms.For<CmsExampleModel>(collection).GetPage(1).GetPerPage(2)),
+            ("Pagination: Page 2, 2 items", () => AppAmbit.Cms.For<CmsExampleModel>(collection).GetPage(2).GetPerPage(2)),
         };
 
         var filterNames = _cmsFilters.Select(f => f.Label).ToList();
@@ -403,7 +403,7 @@ public class MainActivity : Activity
         arrayAdapter.SetDropDownViewResource(Android.Resource.Layout.SimpleSpinnerDropDownItem);
         spinner.Adapter = arrayAdapter;
 
-        async Task LoadResults(AppAmbit.CmsQueryBuilder<CmsExampleModel> query)
+        async Task LoadResults(AppAmbit.ICmsQueryBuilder<CmsExampleModel> query)
         {
             try
             {
@@ -421,7 +421,7 @@ public class MainActivity : Activity
 
         btnGetAll.Click += async (s, e) => 
         {
-            await AppAmbit.Cms.Clear("sistema_de_gestion_de_propiedades_de_una_marinaclub_nautico");
+            await AppAmbit.Cms.ClearCache("sistema_de_gestion_de_propiedades_de_una_marinaclub_nautico");
             await LoadResults(AppAmbit.Cms.For<CmsExampleModel>(collection));
         };
 

--- a/samples/AppAmbit.App.Maui.Native.Android/MainActivity.cs
+++ b/samples/AppAmbit.App.Maui.Native.Android/MainActivity.cs
@@ -39,7 +39,7 @@ public class MainActivity : Activity
         //Uncomment the line for automatic session management
         //Analytics.EnableManualSession();
         AppAmbit.RemoteConfig.Enable();
-        AppAmbitSdk.Start("<YOUR-APPKEY>");
+        AppAmbitSdk.Start("581a777b-4c6f-4290-93db-834c08c97e37");
 
         PushNotifications.Start(this);
         PushNotifications.SetNotificationCustomizer(new SimpleNotificationCustomizer());
@@ -377,7 +377,9 @@ public class MainActivity : Activity
         var etSearch = Find<EditText>("et_cms_search");
         var btnSearch = Find<Button>("btn_cms_search");
         var btnGetAll = Find<Button>("btn_cms_get_all");
+        var progress = Find<ProgressBar>("progress_cms_loading");
         var recycler = Find<AndroidX.RecyclerView.Widget.RecyclerView>("recycler_cms");
+        var tvEmpty = Find<TextView>("tv_cms_empty");
 
         var adapter = new CmsAdapter();
         recycler.SetLayoutManager(new AndroidX.RecyclerView.Widget.LinearLayoutManager(this));
@@ -403,25 +405,42 @@ public class MainActivity : Activity
         arrayAdapter.SetDropDownViewResource(Android.Resource.Layout.SimpleSpinnerDropDownItem);
         spinner.Adapter = arrayAdapter;
 
+        void SetLoading(bool isLoading)
+        {
+            RunOnUiThread(() =>
+            {
+                progress.Visibility = isLoading ? Android.Views.ViewStates.Visible : Android.Views.ViewStates.Gone;
+                btnApply.Enabled = !isLoading;
+                btnSearch.Enabled = !isLoading;
+                btnGetAll.Enabled = !isLoading;
+            });
+        }
+
         async Task LoadResults(AppAmbit.ICmsQueryBuilder<CmsExampleModel> query)
         {
+            SetLoading(true);
             try
             {
                 var items = await query.GetListAsync();
-                RunOnUiThread(() => adapter.UpdateData(items));
-
-                if (items.Count == 0)
-                    ShowAlert("Info", "No entries found. Cache may be empty.");
+                RunOnUiThread(() =>
+                {
+                    adapter.UpdateData(items);
+                    tvEmpty.Visibility = items.Count == 0 ? Android.Views.ViewStates.Visible : Android.Views.ViewStates.Gone;
+                });
             }
             catch (Exception ex)
             {
                 ShowAlert("Error", ex.Message);
             }
+            finally
+            {
+                SetLoading(false);
+            }
         }
 
         btnGetAll.Click += async (s, e) => 
         {
-            await AppAmbit.Cms.ClearCache("sistema_de_gestion_de_propiedades_de_una_marinaclub_nautico");
+            await AppAmbit.Cms.ClearCache(collection);
             await LoadResults(AppAmbit.Cms.Content<CmsExampleModel>(collection));
         };
 

--- a/samples/AppAmbit.App.Maui.Native.Android/MainActivity.cs
+++ b/samples/AppAmbit.App.Maui.Native.Android/MainActivity.cs
@@ -387,15 +387,15 @@ public class MainActivity : Activity
 
         _cmsFilters = new()
         {
-            ("Equals: item_sku = TEC-02", () => AppAmbit.Cms.For<CmsExampleModel>(collection).Equals("item_sku", "TEC-02")),
-            ("Not Equals: item_sku ≠ TEC-02", () => AppAmbit.Cms.For<CmsExampleModel>(collection).NotEquals("item_sku", "TEC-02")),
-            ("Contains: product_name contains 'Pro'", () => AppAmbit.Cms.For<CmsExampleModel>(collection).Contains("product_name", "Pro")),
-            ("Starts With: item_sku starts with 'TEC'", () => AppAmbit.Cms.For<CmsExampleModel>(collection).StartsWith("item_sku", "TEC")),
-            ("In List: [TEC-01, TEC-02]", () => AppAmbit.Cms.For<CmsExampleModel>(collection).InList("item_sku", new[] { "TEC-01", "TEC-02" })),
-            ("Greater Than: price > 500", () => AppAmbit.Cms.For<CmsExampleModel>(collection).GreaterThan("price", 500)),
-            ("Order By price DESC", () => AppAmbit.Cms.For<CmsExampleModel>(collection).OrderByDescending("price")),
-            ("Pagination: Page 1, 2 items", () => AppAmbit.Cms.For<CmsExampleModel>(collection).GetPage(1).GetPerPage(2)),
-            ("Pagination: Page 2, 2 items", () => AppAmbit.Cms.For<CmsExampleModel>(collection).GetPage(2).GetPerPage(2)),
+            ("Equals: item_sku = TEC-02", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).Equals("item_sku", "TEC-02")),
+            ("Not Equals: item_sku ≠ TEC-02", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).NotEquals("item_sku", "TEC-02")),
+            ("Contains: product_name contains 'Pro'", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).Contains("product_name", "Pro")),
+            ("Starts With: item_sku starts with 'TEC'", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).StartsWith("item_sku", "TEC")),
+            ("In List: [TEC-01, TEC-02]", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).InList("item_sku", new[] { "TEC-01", "TEC-02" })),
+            ("Greater Than: price > 500", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).GreaterThan("price", 500)),
+            ("Order By price DESC", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).OrderByDescending("price")),
+            ("Pagination: Page 1, 2 items", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).GetPage(1).GetPerPage(2)),
+            ("Pagination: Page 2, 2 items", () => AppAmbit.Cms.Content<CmsExampleModel>(collection).GetPage(2).GetPerPage(2)),
         };
 
         var filterNames = _cmsFilters.Select(f => f.Label).ToList();
@@ -422,7 +422,7 @@ public class MainActivity : Activity
         btnGetAll.Click += async (s, e) => 
         {
             await AppAmbit.Cms.ClearCache("sistema_de_gestion_de_propiedades_de_una_marinaclub_nautico");
-            await LoadResults(AppAmbit.Cms.For<CmsExampleModel>(collection));
+            await LoadResults(AppAmbit.Cms.Content<CmsExampleModel>(collection));
         };
 
         btnApply.Click += async (s, e) =>
@@ -439,7 +439,7 @@ public class MainActivity : Activity
         {
             var term = etSearch.Text?.Trim();
             if (!string.IsNullOrEmpty(term))
-                await LoadResults(AppAmbit.Cms.For<CmsExampleModel>(collection).Search(term));
+                await LoadResults(AppAmbit.Cms.Content<CmsExampleModel>(collection).Search(term));
         };
     }
 }

--- a/samples/AppAmbit.App.Maui.Native.Android/MainActivity.cs
+++ b/samples/AppAmbit.App.Maui.Native.Android/MainActivity.cs
@@ -39,7 +39,7 @@ public class MainActivity : Activity
         //Uncomment the line for automatic session management
         //Analytics.EnableManualSession();
         AppAmbit.RemoteConfig.Enable();
-        AppAmbitSdk.Start("581a777b-4c6f-4290-93db-834c08c97e37");
+        AppAmbitSdk.Start("<YOUR-APPKEY>");
 
         PushNotifications.Start(this);
         PushNotifications.SetNotificationCustomizer(new SimpleNotificationCustomizer());

--- a/samples/AppAmbit.App.Maui.Native.Android/Models/CmsExampleModel.cs
+++ b/samples/AppAmbit.App.Maui.Native.Android/Models/CmsExampleModel.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace AppAmbitTestingAppAndroid.Models;
+
+public class CmsExampleModel
+{
+    [JsonProperty("price")]
+    public decimal Price { get; set; }
+
+    [JsonProperty("category")]
+    public string? Category { get; set; }
+
+    [JsonProperty("in_stock")]
+    public bool InStock { get; set; }
+
+    [JsonProperty("item_sku")]
+    public string? ItemSku { get; set; }
+
+    [JsonProperty("entry_date")]
+    public string? EntryDate { get; set; }
+
+    [JsonProperty("description")]
+    public string? Description { get; set; }
+
+    [JsonProperty("product_name")]
+    public string? ProductName { get; set; }
+
+    [JsonProperty("product_image")]
+    public string? ProductImage { get; set; }
+
+    [JsonProperty("support_email")]
+    public string? SupportEmail { get; set; }
+
+    [JsonProperty("technical_specs")]
+    public Dictionary<string, string>? TechnicalSpecs { get; set; }
+
+    [JsonProperty("id")]
+    public string? Id { get; set; }
+
+    [JsonProperty("published_at")]
+    public DateTimeOffset PublishedAt { get; set; }
+
+    [JsonProperty("created_at")]
+    public DateTimeOffset CreatedAt { get; set; }
+
+    [JsonProperty("updated_at")]
+    public DateTimeOffset UpdatedAt { get; set; }
+}

--- a/samples/AppAmbit.App.Maui.Native.Android/Models/CmsExampleModel.cs
+++ b/samples/AppAmbit.App.Maui.Native.Android/Models/CmsExampleModel.cs
@@ -10,7 +10,7 @@ public class CmsExampleModel
     public decimal Price { get; set; }
 
     [JsonProperty("category")]
-    public string? Category { get; set; }
+    public List<string>? Category { get; set; }
 
     [JsonProperty("in_stock")]
     public bool InStock { get; set; }
@@ -29,6 +29,9 @@ public class CmsExampleModel
 
     [JsonProperty("product_image")]
     public string? ProductImage { get; set; }
+
+    [JsonProperty("product_image_url")]
+    public string? ProductImageUrl { get; set; }
 
     [JsonProperty("support_email")]
     public string? SupportEmail { get; set; }

--- a/samples/AppAmbit.App.Maui.Native.Android/Resources/layout/activity_main.xml
+++ b/samples/AppAmbit.App.Maui.Native.Android/Resources/layout/activity_main.xml
@@ -17,7 +17,7 @@
         android:layout_width="match_parent"
         android:layout_height="56dp"
         android:orientation="horizontal"
-        android:weightSum="3"
+        android:weightSum="4"
         android:padding="8dp"
         android:elevation="8dp"
         android:background="@android:color/white">
@@ -45,5 +45,13 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:text="Config" />
+
+        <Button
+            android:id="@+id/btn_nav_cms"
+            style="@style/AppButton.Nav"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:text="CMS" />
     </LinearLayout>
 </LinearLayout>

--- a/samples/AppAmbit.App.Maui.Native.Android/Resources/layout/fragment_cms.xml
+++ b/samples/AppAmbit.App.Maui.Native.Android/Resources/layout/fragment_cms.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp"
+    android:background="@color/app_surface">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="CMS Query Builder"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        android:textColor="@android:color/black"
+        android:gravity="center"
+        android:layout_marginBottom="16dp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginBottom="8dp">
+
+        <Spinner
+            android:id="@+id/spin_cms_filters"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_gravity="center_vertical" />
+
+        <Button
+            android:id="@+id/btn_cms_apply_filter"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Apply" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginBottom="8dp">
+
+        <EditText
+            android:id="@+id/et_cms_search"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:hint="Search term..."
+            android:singleLine="true" />
+
+        <Button
+            android:id="@+id/btn_cms_search"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Search" />
+    </LinearLayout>
+
+    <Button
+        android:id="@+id/btn_cms_get_all"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Get All List"
+        android:layout_marginBottom="8dp" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_cms"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:clipToPadding="false"
+        android:paddingBottom="16dp" />
+
+</LinearLayout>

--- a/samples/AppAmbit.App.Maui.Native.Android/Resources/layout/fragment_cms.xml
+++ b/samples/AppAmbit.App.Maui.Native.Android/Resources/layout/fragment_cms.xml
@@ -64,6 +64,15 @@
         android:text="Get All List"
         android:layout_marginBottom="8dp" />
 
+    <ProgressBar
+        android:id="@+id/progress_cms_loading"
+        style="?android:attr/progressBarStyleHorizontal"
+        android:layout_width="match_parent"
+        android:layout_height="3dp"
+        android:layout_marginBottom="8dp"
+        android:indeterminate="true"
+        android:visibility="gone" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recycler_cms"
         android:layout_width="match_parent"
@@ -71,5 +80,16 @@
         android:layout_weight="1"
         android:clipToPadding="false"
         android:paddingBottom="16dp" />
+
+    <TextView
+        android:id="@+id/tv_cms_empty"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="No entries found."
+        android:textSize="14sp"
+        android:textColor="@android:color/darker_gray"
+        android:gravity="center"
+        android:visibility="gone"
+        android:layout_marginTop="32dp" />
 
 </LinearLayout>

--- a/samples/AppAmbit.App.Maui.Native.Android/Resources/layout/item_cms.xml
+++ b/samples/AppAmbit.App.Maui.Native.Android/Resources/layout/item_cms.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="12dp"
+    android:layout_marginBottom="8dp"
+    android:background="@android:color/white"
+    android:elevation="2dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+        <TextView
+            android:id="@+id/tv_product_name"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:textStyle="bold"
+            android:textSize="14sp"
+            android:textColor="@android:color/black" />
+        <TextView
+            android:id="@+id/tv_category"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textStyle="bold"
+            android:textSize="11sp"
+            android:textColor="#1976D2"
+            android:layout_marginStart="8dp" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/tv_description"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="12sp"
+        android:textColor="@android:color/darker_gray"
+        android:maxLines="2"
+        android:ellipsize="end"
+        android:layout_marginTop="4dp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginTop="8dp">
+
+        <TextView
+            android:id="@+id/tv_sku"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="11sp"
+            android:textColor="@android:color/darker_gray"
+            android:layout_marginEnd="12dp" />
+
+        <TextView
+            android:id="@+id/tv_price"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="11sp"
+            android:textStyle="bold"
+            android:textColor="#228B22"
+            android:layout_marginEnd="12dp" />
+
+        <TextView
+            android:id="@+id/tv_stock"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:textSize="11sp"
+            android:textColor="#607D8B" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/tv_support"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="11sp"
+        android:textColor="@android:color/darker_gray"
+        android:layout_marginTop="4dp" />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="#EEEEEE"
+        android:layout_marginTop="4dp"
+        android:layout_marginBottom="4dp"/>
+
+    <TextView
+        android:id="@+id/tv_id"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="10sp"
+        android:textColor="#BDBDBD"
+        android:ellipsize="middle"
+        android:singleLine="true"/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginTop="2dp">
+        <TextView
+            android:id="@+id/tv_created_at"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:textSize="10sp"
+            android:textColor="@android:color/darker_gray" />
+        <TextView
+            android:id="@+id/tv_published_at"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:textSize="10sp"
+            android:textColor="@android:color/darker_gray" />
+        <TextView
+            android:id="@+id/tv_updated_at"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:textSize="10sp"
+            android:textColor="@android:color/darker_gray" />
+    </LinearLayout>
+</LinearLayout>

--- a/samples/AppAmbit.App.Maui.Native.Android/Resources/layout/item_cms.xml
+++ b/samples/AppAmbit.App.Maui.Native.Android/Resources/layout/item_cms.xml
@@ -8,6 +8,14 @@
     android:background="@android:color/white"
     android:elevation="2dp">
 
+    <ImageView
+        android:id="@+id/iv_product"
+        android:layout_width="match_parent"
+        android:layout_height="150dp"
+        android:scaleType="centerCrop"
+        android:background="#F0F0F0"
+        android:layout_marginBottom="8dp" />
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/samples/AppAmbit.App.Maui.Native.Android/Utils/ImageUtils.cs
+++ b/samples/AppAmbit.App.Maui.Native.Android/Utils/ImageUtils.cs
@@ -1,0 +1,34 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using Android.Graphics;
+using Android.Widget;
+
+namespace AppAmbitTestingAppAndroid.Utils;
+
+internal static class ImageUtils
+{
+    private static readonly HttpClient _http = new();
+
+    /// <summary>
+    /// Loads an image from <paramref name="url"/> on a background thread and sets it on
+    /// <paramref name="imageView"/> on the UI thread. Uses <paramref name="tag"/> to discard
+    /// results that arrive after the view has been recycled to a different item.
+    /// </summary>
+    internal static void LoadAsync(string url, ImageView imageView, string tag)
+    {
+        imageView.SetImageDrawable(null);
+        imageView.Tag = new Java.Lang.String(tag);
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                var bytes = await _http.GetByteArrayAsync(url);
+                var bmp = await BitmapFactory.DecodeByteArrayAsync(bytes, 0, bytes.Length);
+                if (bmp != null && imageView.Tag?.ToString() == tag)
+                    imageView.Post(() => imageView.SetImageBitmap(bmp));
+            }
+            catch { }
+        });
+    }
+}

--- a/samples/AppAmbit.App.Maui.Native.iOS/AppDelegate.cs
+++ b/samples/AppAmbit.App.Maui.Native.iOS/AppDelegate.cs
@@ -15,7 +15,7 @@ public class AppDelegate : UIApplicationDelegate
     public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
     {
         AppAmbit.RemoteConfig.Enable();
-        AppAmbitSdk.Start("581a777b-4c6f-4290-93db-834c08c97e37");
+        AppAmbitSdk.Start("<YOUR-APPKEY>");
         PushNotifications.Start();
 
         Window = new UIWindow(UIScreen.MainScreen.Bounds);

--- a/samples/AppAmbit.App.Maui.Native.iOS/AppDelegate.cs
+++ b/samples/AppAmbit.App.Maui.Native.iOS/AppDelegate.cs
@@ -15,7 +15,7 @@ public class AppDelegate : UIApplicationDelegate
     public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
     {
         AppAmbit.RemoteConfig.Enable();
-        AppAmbitSdk.Start("<YOUR-APPKEY>");
+        AppAmbitSdk.Start("581a777b-4c6f-4290-93db-834c08c97e37");
         PushNotifications.Start();
 
         Window = new UIWindow(UIScreen.MainScreen.Bounds);

--- a/samples/AppAmbit.App.Maui.Native.iOS/CmsViewController.cs
+++ b/samples/AppAmbit.App.Maui.Native.iOS/CmsViewController.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using AppAmbit;
 using AppAmbitTestingiOS.Models;
+using AppAmbitTestingiOS.Utils;
 using Foundation;
 using UIKit;
 
@@ -15,6 +16,7 @@ public class CmsViewController : UIViewController, IUISearchBarDelegate
     private UISearchBar _searchBar = null!;
     private UIButton _btnFilter = null!;
     private UIButton _btnGetAll = null!;
+    private UILabel _emptyLabel = null!;
 
     private CmsTableViewSource _source = null!;
     private const string CollectionName = "tech_inventory";
@@ -65,7 +67,7 @@ public class CmsViewController : UIViewController, IUISearchBarDelegate
         _btnGetAll.TranslatesAutoresizingMaskIntoConstraints = false;
         _btnGetAll.TouchUpInside += async (s, e) =>
         {
-            await Cms.ClearCache("sistema_de_gestion_de_propiedades_de_una_marinaclub_nautico");
+            await Cms.ClearCache(CollectionName);
             await LoadResults(Cms.Content<CmsExampleModel>(CollectionName));
         };
 
@@ -87,13 +89,25 @@ public class CmsViewController : UIViewController, IUISearchBarDelegate
         _tableView = new UITableView
         {
             TranslatesAutoresizingMaskIntoConstraints = false,
-            RowHeight = 160
+            RowHeight = UITableView.AutomaticDimension,
+            EstimatedRowHeight = 330f
         };
         _tableView.RegisterClassForCellReuse(typeof(CmsCell), CmsCell.Key);
         _source = new CmsTableViewSource();
         _tableView.Source = _source;
 
-        View!.AddSubviews(_searchBar, _btnFilter, _btnGetAll, _tableView);
+        // Empty label
+        _emptyLabel = new UILabel
+        {
+            Text = "No entries found.",
+            TextColor = UIColor.SecondaryLabel,
+            Font = UIFont.SystemFontOfSize(14),
+            TextAlignment = UITextAlignment.Center,
+            Hidden = true,
+            TranslatesAutoresizingMaskIntoConstraints = false
+        };
+
+        View!.AddSubviews(_searchBar, _btnFilter, _btnGetAll, _tableView, _emptyLabel);
 
         // Constraints
         var g = View.SafeAreaLayoutGuide;
@@ -114,7 +128,10 @@ public class CmsViewController : UIViewController, IUISearchBarDelegate
             _tableView.TopAnchor.ConstraintEqualTo(_btnFilter.BottomAnchor, 8),
             _tableView.LeadingAnchor.ConstraintEqualTo(g.LeadingAnchor),
             _tableView.TrailingAnchor.ConstraintEqualTo(g.TrailingAnchor),
-            _tableView.BottomAnchor.ConstraintEqualTo(g.BottomAnchor)
+            _tableView.BottomAnchor.ConstraintEqualTo(g.BottomAnchor),
+
+            _emptyLabel.CenterXAnchor.ConstraintEqualTo(_tableView.CenterXAnchor),
+            _emptyLabel.CenterYAnchor.ConstraintEqualTo(_tableView.CenterYAnchor),
         });
     }
 
@@ -136,13 +153,7 @@ public class CmsViewController : UIViewController, IUISearchBarDelegate
             {
                 _source.UpdateData(items);
                 _tableView.ReloadData();
-                
-                if (items.Count == 0)
-                {
-                    var alert = UIAlertController.Create("Info", "No entries found. Cache may be empty.", UIAlertControllerStyle.Alert);
-                    alert.AddAction(UIAlertAction.Create("OK", UIAlertActionStyle.Default, null));
-                    PresentViewController(alert, true, null);
-                }
+                _emptyLabel.Hidden = items.Count != 0;
             });
         }
         catch (Exception ex)
@@ -180,6 +191,7 @@ public class CmsCell : UITableViewCell
 {
     public static readonly NSString Key = new NSString(nameof(CmsCell));
 
+    private UIImageView _imgProduct = null!;
     private UILabel _lblProduct = null!;
     private UILabel _lblCategory = null!;
     private UILabel _lblDesc = null!;
@@ -192,22 +204,38 @@ public class CmsCell : UITableViewCell
     public CmsCell(UITableViewCellStyle style, NSString reuseIdentifier) : base(style, reuseIdentifier)
     {
         SelectionStyle = UITableViewCellSelectionStyle.None;
-        
+
+        _imgProduct = new UIImageView
+        {
+            ContentMode = UIViewContentMode.ScaleAspectFill,
+            ClipsToBounds = true,
+            BackgroundColor = UIColor.SystemGray5,
+            TranslatesAutoresizingMaskIntoConstraints = false
+        };
+        _imgProduct.Layer.CornerRadius = 0;
+
         _lblProduct = new UILabel { Font = UIFont.BoldSystemFontOfSize(16), TranslatesAutoresizingMaskIntoConstraints = false };
         _lblCategory = new UILabel { Font = UIFont.BoldSystemFontOfSize(11), TextColor = UIColor.SystemBlue, TranslatesAutoresizingMaskIntoConstraints = false, TextAlignment = UITextAlignment.Right };
         _lblDesc = new UILabel { Font = UIFont.SystemFontOfSize(12), TextColor = UIColor.DarkGray, Lines = 2, TranslatesAutoresizingMaskIntoConstraints = false };
-        
+
         _lblPrice = new UILabel { Font = UIFont.BoldSystemFontOfSize(13), TextColor = UIColor.SystemGreen, TranslatesAutoresizingMaskIntoConstraints = false };
         _lblSkuLine = new UILabel { Font = UIFont.SystemFontOfSize(12), TextColor = UIColor.Gray, TranslatesAutoresizingMaskIntoConstraints = false };
-        
+
         _lblSupport = new UILabel { Font = UIFont.SystemFontOfSize(11), TextColor = UIColor.LightGray, TranslatesAutoresizingMaskIntoConstraints = false };
         _lblIdAndDates = new UILabel { Font = UIFont.SystemFontOfSize(10), TextColor = UIColor.LightGray, Lines = 2, TranslatesAutoresizingMaskIntoConstraints = false, LineBreakMode = UILineBreakMode.MiddleTruncation };
 
-        ContentView.AddSubviews(_lblProduct, _lblCategory, _lblDesc, _lblPrice, _lblSkuLine, _lblSupport, _lblIdAndDates);
+        ContentView.AddSubviews(_imgProduct, _lblProduct, _lblCategory, _lblDesc, _lblPrice, _lblSkuLine, _lblSupport, _lblIdAndDates);
 
         NSLayoutConstraint.ActivateConstraints(new[]
         {
-            _lblProduct.TopAnchor.ConstraintEqualTo(ContentView.TopAnchor, 12),
+            // Image — full width banner at top
+            _imgProduct.TopAnchor.ConstraintEqualTo(ContentView.TopAnchor),
+            _imgProduct.LeadingAnchor.ConstraintEqualTo(ContentView.LeadingAnchor),
+            _imgProduct.TrailingAnchor.ConstraintEqualTo(ContentView.TrailingAnchor),
+            _imgProduct.HeightAnchor.ConstraintEqualTo(150f),
+
+            // Product name + category below image
+            _lblProduct.TopAnchor.ConstraintEqualTo(_imgProduct.BottomAnchor, 12),
             _lblProduct.LeadingAnchor.ConstraintEqualTo(ContentView.LeadingAnchor, 16),
             _lblProduct.TrailingAnchor.ConstraintLessThanOrEqualTo(_lblCategory.LeadingAnchor, -8),
 
@@ -231,17 +259,23 @@ public class CmsCell : UITableViewCell
             _lblIdAndDates.TopAnchor.ConstraintEqualTo(_lblSupport.BottomAnchor, 8),
             _lblIdAndDates.LeadingAnchor.ConstraintEqualTo(ContentView.LeadingAnchor, 16),
             _lblIdAndDates.TrailingAnchor.ConstraintEqualTo(ContentView.TrailingAnchor, -16),
+            _lblIdAndDates.BottomAnchor.ConstraintEqualTo(ContentView.BottomAnchor, -12),
         });
     }
 
     public void Bind(CmsExampleModel item)
     {
         _lblProduct.Text = item.ProductName;
-        _lblCategory.Text = string.IsNullOrEmpty(item.Category) ? "" : $"🏷️ {item.Category}";
+        _lblCategory.Text = item.Category?.Count > 0 ? $"🏷️ {string.Join(", ", item.Category)}" : "";
         _lblDesc.Text = item.Description;
         _lblSkuLine.Text = $"{item.ItemSku}  |  Stock: {item.InStock}";
         _lblPrice.Text = $"${item.Price:F2}";
         _lblSupport.Text = $"📧 {item.SupportEmail}";
         _lblIdAndDates.Text = $"ID: {item.Id}\nCr: {item.CreatedAt:dd/MM/yy} | Pub: {item.PublishedAt:dd/MM/yy} | Upd: {item.UpdatedAt:dd/MM/yy}";
+
+        if (!string.IsNullOrWhiteSpace(item.ProductImageUrl))
+            ImageUtils.LoadAsync(item.ProductImageUrl!, _imgProduct, item.Id ?? item.ProductImageUrl!);
+        else
+            _imgProduct.Image = null;
     }
 }

--- a/samples/AppAmbit.App.Maui.Native.iOS/CmsViewController.cs
+++ b/samples/AppAmbit.App.Maui.Native.iOS/CmsViewController.cs
@@ -19,7 +19,7 @@ public class CmsViewController : UIViewController, IUISearchBarDelegate
     private CmsTableViewSource _source = null!;
     private const string CollectionName = "tech_inventory";
 
-    private List<(string Label, Func<CmsQueryBuilder<CmsExampleModel>> Build)> _cmsFilters = new();
+    private List<(string Label, Func<ICmsQueryBuilder<CmsExampleModel>> Build)> _cmsFilters = new();
 
     public override void ViewDidLoad()
     {
@@ -44,8 +44,8 @@ public class CmsViewController : UIViewController, IUISearchBarDelegate
             ("In List: [TEC-01, TEC-02]", () => Cms.For<CmsExampleModel>(CollectionName).InList("item_sku", new[] { "TEC-01", "TEC-02" })),
             ("Greater Than: price > 500", () => Cms.For<CmsExampleModel>(CollectionName).GreaterThan("price", 500)),
             ("Order By price DESC", () => Cms.For<CmsExampleModel>(CollectionName).OrderByDescending("price")),
-            ("Pagination: Page 1, 2 items", () => Cms.For<CmsExampleModel>(CollectionName).SetPage(1).SetPerPage(2)),
-            ("Pagination: Page 2, 2 items", () => Cms.For<CmsExampleModel>(CollectionName).SetPage(2).SetPerPage(2)),
+            ("Pagination: Page 1, 2 items", () => Cms.For<CmsExampleModel>(CollectionName).GetPage(1).GetPerPage(2)),
+            ("Pagination: Page 2, 2 items", () => Cms.For<CmsExampleModel>(CollectionName).GetPage(2).GetPerPage(2)),
         };
     }
 
@@ -65,7 +65,7 @@ public class CmsViewController : UIViewController, IUISearchBarDelegate
         _btnGetAll.TranslatesAutoresizingMaskIntoConstraints = false;
         _btnGetAll.TouchUpInside += async (s, e) =>
         {
-            await Cms.Clear("sistema_de_gestion_de_propiedades_de_una_marinaclub_nautico");
+            await Cms.ClearCache("sistema_de_gestion_de_propiedades_de_una_marinaclub_nautico");
             await LoadResults(Cms.For<CmsExampleModel>(CollectionName));
         };
 
@@ -127,7 +127,7 @@ public class CmsViewController : UIViewController, IUISearchBarDelegate
             _ = LoadResults(Cms.For<CmsExampleModel>(CollectionName).Search(term));
     }
 
-    private async Task LoadResults(CmsQueryBuilder<CmsExampleModel> query)
+    private async Task LoadResults(ICmsQueryBuilder<CmsExampleModel> query)
     {
         try
         {

--- a/samples/AppAmbit.App.Maui.Native.iOS/CmsViewController.cs
+++ b/samples/AppAmbit.App.Maui.Native.iOS/CmsViewController.cs
@@ -1,0 +1,247 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AppAmbit;
+using AppAmbitTestingiOS.Models;
+using Foundation;
+using UIKit;
+
+namespace AppAmbitTestingiOS;
+
+public class CmsViewController : UIViewController, IUISearchBarDelegate
+{
+    private UITableView _tableView = null!;
+    private UISearchBar _searchBar = null!;
+    private UIButton _btnFilter = null!;
+    private UIButton _btnGetAll = null!;
+
+    private CmsTableViewSource _source = null!;
+    private const string CollectionName = "tech_inventory";
+
+    private List<(string Label, Func<CmsQueryBuilder<CmsExampleModel>> Build)> _cmsFilters = new();
+
+    public override void ViewDidLoad()
+    {
+        base.ViewDidLoad();
+        Title = "CMS Query Builder";
+        View!.BackgroundColor = UIColor.SystemBackground;
+
+        SetupFilters();
+        SetupUI();
+
+        _ = LoadResults(Cms.For<CmsExampleModel>(CollectionName));
+    }
+
+    private void SetupFilters()
+    {
+        _cmsFilters = new()
+        {
+            ("Equals: item_sku = TEC-02", () => Cms.For<CmsExampleModel>(CollectionName).Equals("item_sku", "TEC-02")),
+            ("Not Equals: item_sku ≠ TEC-02", () => Cms.For<CmsExampleModel>(CollectionName).NotEquals("item_sku", "TEC-02")),
+            ("Contains: product_name contains 'Pro'", () => Cms.For<CmsExampleModel>(CollectionName).Contains("product_name", "Pro")),
+            ("Starts With: item_sku starts with 'TEC'", () => Cms.For<CmsExampleModel>(CollectionName).StartsWith("item_sku", "TEC")),
+            ("In List: [TEC-01, TEC-02]", () => Cms.For<CmsExampleModel>(CollectionName).InList("item_sku", new[] { "TEC-01", "TEC-02" })),
+            ("Greater Than: price > 500", () => Cms.For<CmsExampleModel>(CollectionName).GreaterThan("price", 500)),
+            ("Order By price DESC", () => Cms.For<CmsExampleModel>(CollectionName).OrderByDescending("price")),
+            ("Pagination: Page 1, 2 items", () => Cms.For<CmsExampleModel>(CollectionName).SetPage(1).SetPerPage(2)),
+            ("Pagination: Page 2, 2 items", () => Cms.For<CmsExampleModel>(CollectionName).SetPage(2).SetPerPage(2)),
+        };
+    }
+
+    private void SetupUI()
+    {
+        // Search Bar
+        _searchBar = new UISearchBar
+        {
+            Placeholder = "Search term...",
+            Delegate = this,
+            TranslatesAutoresizingMaskIntoConstraints = false
+        };
+
+        // Get All Button
+        _btnGetAll = UIButton.FromType(UIButtonType.System);
+        _btnGetAll.SetTitle("Get All List", UIControlState.Normal);
+        _btnGetAll.TranslatesAutoresizingMaskIntoConstraints = false;
+        _btnGetAll.TouchUpInside += async (s, e) =>
+        {
+            await Cms.Clear("sistema_de_gestion_de_propiedades_de_una_marinaclub_nautico");
+            await LoadResults(Cms.For<CmsExampleModel>(CollectionName));
+        };
+
+        // Filter Menu Button
+        _btnFilter = UIButton.FromType(UIButtonType.System);
+        _btnFilter.SetTitle("Filters 🔽", UIControlState.Normal);
+        _btnFilter.TranslatesAutoresizingMaskIntoConstraints = false;
+        if (OperatingSystem.IsIOSVersionAtLeast(14))
+        {
+            var actions = _cmsFilters.Select(f => UIAction.Create(f.Label, null, null, action =>
+            {
+                _ = LoadResults(f.Build());
+            })).ToArray();
+            _btnFilter.Menu = UIMenu.Create(string.Empty, actions);
+            _btnFilter.ShowsMenuAsPrimaryAction = true;
+        }
+
+        // Table View
+        _tableView = new UITableView
+        {
+            TranslatesAutoresizingMaskIntoConstraints = false,
+            RowHeight = 160
+        };
+        _tableView.RegisterClassForCellReuse(typeof(CmsCell), CmsCell.Key);
+        _source = new CmsTableViewSource();
+        _tableView.Source = _source;
+
+        View!.AddSubviews(_searchBar, _btnFilter, _btnGetAll, _tableView);
+
+        // Constraints
+        var g = View.SafeAreaLayoutGuide;
+        NSLayoutConstraint.ActivateConstraints(new[]
+        {
+            _searchBar.TopAnchor.ConstraintEqualTo(g.TopAnchor),
+            _searchBar.LeadingAnchor.ConstraintEqualTo(g.LeadingAnchor),
+            _searchBar.TrailingAnchor.ConstraintEqualTo(g.TrailingAnchor),
+
+            _btnFilter.TopAnchor.ConstraintEqualTo(_searchBar.BottomAnchor, 8),
+            _btnFilter.LeadingAnchor.ConstraintEqualTo(g.LeadingAnchor, 16),
+            _btnFilter.HeightAnchor.ConstraintEqualTo(44),
+
+            _btnGetAll.TopAnchor.ConstraintEqualTo(_searchBar.BottomAnchor, 8),
+            _btnGetAll.TrailingAnchor.ConstraintEqualTo(g.TrailingAnchor, -16),
+            _btnGetAll.HeightAnchor.ConstraintEqualTo(44),
+
+            _tableView.TopAnchor.ConstraintEqualTo(_btnFilter.BottomAnchor, 8),
+            _tableView.LeadingAnchor.ConstraintEqualTo(g.LeadingAnchor),
+            _tableView.TrailingAnchor.ConstraintEqualTo(g.TrailingAnchor),
+            _tableView.BottomAnchor.ConstraintEqualTo(g.BottomAnchor)
+        });
+    }
+
+    [Export("searchBarSearchButtonClicked:")]
+    public void SearchButtonClicked(UISearchBar searchBar)
+    {
+        searchBar.ResignFirstResponder();
+        var term = searchBar.Text?.Trim();
+        if (!string.IsNullOrEmpty(term))
+            _ = LoadResults(Cms.For<CmsExampleModel>(CollectionName).Search(term));
+    }
+
+    private async Task LoadResults(CmsQueryBuilder<CmsExampleModel> query)
+    {
+        try
+        {
+            var items = await query.GetListAsync();
+            InvokeOnMainThread(() =>
+            {
+                _source.UpdateData(items);
+                _tableView.ReloadData();
+                
+                if (items.Count == 0)
+                {
+                    var alert = UIAlertController.Create("Info", "No entries found. Cache may be empty.", UIAlertControllerStyle.Alert);
+                    alert.AddAction(UIAlertAction.Create("OK", UIAlertActionStyle.Default, null));
+                    PresentViewController(alert, true, null);
+                }
+            });
+        }
+        catch (Exception ex)
+        {
+            InvokeOnMainThread(() =>
+            {
+                var alert = UIAlertController.Create("Error", ex.Message, UIAlertControllerStyle.Alert);
+                alert.AddAction(UIAlertAction.Create("OK", UIAlertActionStyle.Default, null));
+                PresentViewController(alert, true, null);
+            });
+        }
+    }
+}
+
+public class CmsTableViewSource : UITableViewSource
+{
+    private List<CmsExampleModel> _items = new();
+
+    public void UpdateData(List<CmsExampleModel> items)
+    {
+        _items = items;
+    }
+
+    public override nint RowsInSection(UITableView tableview, nint section) => _items.Count;
+
+    public override UITableViewCell GetCell(UITableView tableView, NSIndexPath indexPath)
+    {
+        var cell = (CmsCell)tableView.DequeueReusableCell(CmsCell.Key, indexPath);
+        cell.Bind(_items[indexPath.Row]);
+        return cell;
+    }
+}
+
+public class CmsCell : UITableViewCell
+{
+    public static readonly NSString Key = new NSString(nameof(CmsCell));
+
+    private UILabel _lblProduct = null!;
+    private UILabel _lblCategory = null!;
+    private UILabel _lblDesc = null!;
+    private UILabel _lblPrice = null!;
+    private UILabel _lblSkuLine = null!;
+    private UILabel _lblSupport = null!;
+    private UILabel _lblIdAndDates = null!;
+
+    [Export("initWithStyle:reuseIdentifier:")]
+    public CmsCell(UITableViewCellStyle style, NSString reuseIdentifier) : base(style, reuseIdentifier)
+    {
+        SelectionStyle = UITableViewCellSelectionStyle.None;
+        
+        _lblProduct = new UILabel { Font = UIFont.BoldSystemFontOfSize(16), TranslatesAutoresizingMaskIntoConstraints = false };
+        _lblCategory = new UILabel { Font = UIFont.BoldSystemFontOfSize(11), TextColor = UIColor.SystemBlue, TranslatesAutoresizingMaskIntoConstraints = false, TextAlignment = UITextAlignment.Right };
+        _lblDesc = new UILabel { Font = UIFont.SystemFontOfSize(12), TextColor = UIColor.DarkGray, Lines = 2, TranslatesAutoresizingMaskIntoConstraints = false };
+        
+        _lblPrice = new UILabel { Font = UIFont.BoldSystemFontOfSize(13), TextColor = UIColor.SystemGreen, TranslatesAutoresizingMaskIntoConstraints = false };
+        _lblSkuLine = new UILabel { Font = UIFont.SystemFontOfSize(12), TextColor = UIColor.Gray, TranslatesAutoresizingMaskIntoConstraints = false };
+        
+        _lblSupport = new UILabel { Font = UIFont.SystemFontOfSize(11), TextColor = UIColor.LightGray, TranslatesAutoresizingMaskIntoConstraints = false };
+        _lblIdAndDates = new UILabel { Font = UIFont.SystemFontOfSize(10), TextColor = UIColor.LightGray, Lines = 2, TranslatesAutoresizingMaskIntoConstraints = false, LineBreakMode = UILineBreakMode.MiddleTruncation };
+
+        ContentView.AddSubviews(_lblProduct, _lblCategory, _lblDesc, _lblPrice, _lblSkuLine, _lblSupport, _lblIdAndDates);
+
+        NSLayoutConstraint.ActivateConstraints(new[]
+        {
+            _lblProduct.TopAnchor.ConstraintEqualTo(ContentView.TopAnchor, 12),
+            _lblProduct.LeadingAnchor.ConstraintEqualTo(ContentView.LeadingAnchor, 16),
+            _lblProduct.TrailingAnchor.ConstraintLessThanOrEqualTo(_lblCategory.LeadingAnchor, -8),
+
+            _lblCategory.CenterYAnchor.ConstraintEqualTo(_lblProduct.CenterYAnchor),
+            _lblCategory.TrailingAnchor.ConstraintEqualTo(ContentView.TrailingAnchor, -16),
+            _lblCategory.WidthAnchor.ConstraintGreaterThanOrEqualTo(80),
+
+            _lblDesc.TopAnchor.ConstraintEqualTo(_lblProduct.BottomAnchor, 8),
+            _lblDesc.LeadingAnchor.ConstraintEqualTo(ContentView.LeadingAnchor, 16),
+            _lblDesc.TrailingAnchor.ConstraintEqualTo(ContentView.TrailingAnchor, -16),
+
+            _lblSkuLine.TopAnchor.ConstraintEqualTo(_lblDesc.BottomAnchor, 8),
+            _lblSkuLine.LeadingAnchor.ConstraintEqualTo(ContentView.LeadingAnchor, 16),
+
+            _lblPrice.CenterYAnchor.ConstraintEqualTo(_lblSkuLine.CenterYAnchor),
+            _lblPrice.LeadingAnchor.ConstraintEqualTo(_lblSkuLine.TrailingAnchor, 16),
+
+            _lblSupport.TopAnchor.ConstraintEqualTo(_lblSkuLine.BottomAnchor, 8),
+            _lblSupport.LeadingAnchor.ConstraintEqualTo(ContentView.LeadingAnchor, 16),
+
+            _lblIdAndDates.TopAnchor.ConstraintEqualTo(_lblSupport.BottomAnchor, 8),
+            _lblIdAndDates.LeadingAnchor.ConstraintEqualTo(ContentView.LeadingAnchor, 16),
+            _lblIdAndDates.TrailingAnchor.ConstraintEqualTo(ContentView.TrailingAnchor, -16),
+        });
+    }
+
+    public void Bind(CmsExampleModel item)
+    {
+        _lblProduct.Text = item.ProductName;
+        _lblCategory.Text = string.IsNullOrEmpty(item.Category) ? "" : $"🏷️ {item.Category}";
+        _lblDesc.Text = item.Description;
+        _lblSkuLine.Text = $"{item.ItemSku}  |  Stock: {item.InStock}";
+        _lblPrice.Text = $"${item.Price:F2}";
+        _lblSupport.Text = $"📧 {item.SupportEmail}";
+        _lblIdAndDates.Text = $"ID: {item.Id}\nCr: {item.CreatedAt:dd/MM/yy} | Pub: {item.PublishedAt:dd/MM/yy} | Upd: {item.UpdatedAt:dd/MM/yy}";
+    }
+}

--- a/samples/AppAmbit.App.Maui.Native.iOS/CmsViewController.cs
+++ b/samples/AppAmbit.App.Maui.Native.iOS/CmsViewController.cs
@@ -30,22 +30,22 @@ public class CmsViewController : UIViewController, IUISearchBarDelegate
         SetupFilters();
         SetupUI();
 
-        _ = LoadResults(Cms.For<CmsExampleModel>(CollectionName));
+        _ = LoadResults(Cms.Content<CmsExampleModel>(CollectionName));
     }
 
     private void SetupFilters()
     {
         _cmsFilters = new()
         {
-            ("Equals: item_sku = TEC-02", () => Cms.For<CmsExampleModel>(CollectionName).Equals("item_sku", "TEC-02")),
-            ("Not Equals: item_sku ≠ TEC-02", () => Cms.For<CmsExampleModel>(CollectionName).NotEquals("item_sku", "TEC-02")),
-            ("Contains: product_name contains 'Pro'", () => Cms.For<CmsExampleModel>(CollectionName).Contains("product_name", "Pro")),
-            ("Starts With: item_sku starts with 'TEC'", () => Cms.For<CmsExampleModel>(CollectionName).StartsWith("item_sku", "TEC")),
-            ("In List: [TEC-01, TEC-02]", () => Cms.For<CmsExampleModel>(CollectionName).InList("item_sku", new[] { "TEC-01", "TEC-02" })),
-            ("Greater Than: price > 500", () => Cms.For<CmsExampleModel>(CollectionName).GreaterThan("price", 500)),
-            ("Order By price DESC", () => Cms.For<CmsExampleModel>(CollectionName).OrderByDescending("price")),
-            ("Pagination: Page 1, 2 items", () => Cms.For<CmsExampleModel>(CollectionName).GetPage(1).GetPerPage(2)),
-            ("Pagination: Page 2, 2 items", () => Cms.For<CmsExampleModel>(CollectionName).GetPage(2).GetPerPage(2)),
+            ("Equals: item_sku = TEC-02", () => Cms.Content<CmsExampleModel>(CollectionName).Equals("item_sku", "TEC-02")),
+            ("Not Equals: item_sku ≠ TEC-02", () => Cms.Content<CmsExampleModel>(CollectionName).NotEquals("item_sku", "TEC-02")),
+            ("Contains: product_name contains 'Pro'", () => Cms.Content<CmsExampleModel>(CollectionName).Contains("product_name", "Pro")),
+            ("Starts With: item_sku starts with 'TEC'", () => Cms.Content<CmsExampleModel>(CollectionName).StartsWith("item_sku", "TEC")),
+            ("In List: [TEC-01, TEC-02]", () => Cms.Content<CmsExampleModel>(CollectionName).InList("item_sku", new[] { "TEC-01", "TEC-02" })),
+            ("Greater Than: price > 500", () => Cms.Content<CmsExampleModel>(CollectionName).GreaterThan("price", 500)),
+            ("Order By price DESC", () => Cms.Content<CmsExampleModel>(CollectionName).OrderByDescending("price")),
+            ("Pagination: Page 1, 2 items", () => Cms.Content<CmsExampleModel>(CollectionName).GetPage(1).GetPerPage(2)),
+            ("Pagination: Page 2, 2 items", () => Cms.Content<CmsExampleModel>(CollectionName).GetPage(2).GetPerPage(2)),
         };
     }
 
@@ -66,7 +66,7 @@ public class CmsViewController : UIViewController, IUISearchBarDelegate
         _btnGetAll.TouchUpInside += async (s, e) =>
         {
             await Cms.ClearCache("sistema_de_gestion_de_propiedades_de_una_marinaclub_nautico");
-            await LoadResults(Cms.For<CmsExampleModel>(CollectionName));
+            await LoadResults(Cms.Content<CmsExampleModel>(CollectionName));
         };
 
         // Filter Menu Button
@@ -124,7 +124,7 @@ public class CmsViewController : UIViewController, IUISearchBarDelegate
         searchBar.ResignFirstResponder();
         var term = searchBar.Text?.Trim();
         if (!string.IsNullOrEmpty(term))
-            _ = LoadResults(Cms.For<CmsExampleModel>(CollectionName).Search(term));
+            _ = LoadResults(Cms.Content<CmsExampleModel>(CollectionName).Search(term));
     }
 
     private async Task LoadResults(ICmsQueryBuilder<CmsExampleModel> query)

--- a/samples/AppAmbit.App.Maui.Native.iOS/CmsViewController.cs
+++ b/samples/AppAmbit.App.Maui.Native.iOS/CmsViewController.cs
@@ -10,7 +10,7 @@ using UIKit;
 
 namespace AppAmbitTestingiOS;
 
-public class CmsViewController : UIViewController, IUISearchBarDelegate
+public class CmsViewController : UIViewController
 {
     private UITableView _tableView = null!;
     private UISearchBar _searchBar = null!;
@@ -22,75 +22,155 @@ public class CmsViewController : UIViewController, IUISearchBarDelegate
     private const string CollectionName = "tech_inventory";
 
     private List<(string Label, Func<ICmsQueryBuilder<CmsExampleModel>> Build)> _cmsFilters = new();
+    private int _selectedFilterIndex = -1;
 
     public override void ViewDidLoad()
     {
         base.ViewDidLoad();
-        Title = "CMS Query Builder";
+        Title = "CMS Showcase";
         View!.BackgroundColor = UIColor.SystemBackground;
 
         SetupFilters();
         SetupUI();
-
-        _ = LoadResults(Cms.Content<CmsExampleModel>(CollectionName));
     }
 
     private void SetupFilters()
     {
         _cmsFilters = new()
         {
+            // Equality
             ("Equals: item_sku = TEC-02", () => Cms.Content<CmsExampleModel>(CollectionName).Equals("item_sku", "TEC-02")),
             ("Not Equals: item_sku ≠ TEC-02", () => Cms.Content<CmsExampleModel>(CollectionName).NotEquals("item_sku", "TEC-02")),
+            ("In List: category = Cat 1", () => Cms.Content<CmsExampleModel>(CollectionName).InList("category", new[] { "Cat 1" })),
+            ("Boolean: in_stock = true", () => Cms.Content<CmsExampleModel>(CollectionName).Equals("in_stock", "true")),
+
+            // Text matching
             ("Contains: product_name contains 'Pro'", () => Cms.Content<CmsExampleModel>(CollectionName).Contains("product_name", "Pro")),
             ("Starts With: item_sku starts with 'TEC'", () => Cms.Content<CmsExampleModel>(CollectionName).StartsWith("item_sku", "TEC")),
-            ("In List: [TEC-01, TEC-02]", () => Cms.Content<CmsExampleModel>(CollectionName).InList("item_sku", new[] { "TEC-01", "TEC-02" })),
+
+            // List membership
+            ("In List: item_sku in [TEC-01, TEC-02]", () => Cms.Content<CmsExampleModel>(CollectionName).InList("item_sku", new[] { "TEC-01", "TEC-02" })),
+            ("Not In List: item_sku not in [TEC-01, TEC-02]", () => Cms.Content<CmsExampleModel>(CollectionName).NotInList("item_sku", new[] { "TEC-01", "TEC-02" })),
+
+            // Numeric comparisons
             ("Greater Than: price > 500", () => Cms.Content<CmsExampleModel>(CollectionName).GreaterThan("price", 500)),
+            ("Greater Or Equal: price >= 500", () => Cms.Content<CmsExampleModel>(CollectionName).GreaterThanOrEqual("price", 500)),
+            ("Less Than: price < 500", () => Cms.Content<CmsExampleModel>(CollectionName).LessThan("price", 500)),
+            ("Less Or Equal: price <= 500", () => Cms.Content<CmsExampleModel>(CollectionName).LessThanOrEqual("price", 500)),
+
+            // Sorting
+            ("Order By product_name ASC", () => Cms.Content<CmsExampleModel>(CollectionName).OrderByAscending("product_name")),
+            ("Order By product_name DESC", () => Cms.Content<CmsExampleModel>(CollectionName).OrderByDescending("product_name")),
+            ("Order By price ASC", () => Cms.Content<CmsExampleModel>(CollectionName).OrderByAscending("price")),
             ("Order By price DESC", () => Cms.Content<CmsExampleModel>(CollectionName).OrderByDescending("price")),
-            ("Pagination: Page 1, 2 items", () => Cms.Content<CmsExampleModel>(CollectionName).GetPage(1).GetPerPage(2)),
-            ("Pagination: Page 2, 2 items", () => Cms.Content<CmsExampleModel>(CollectionName).GetPage(2).GetPerPage(2)),
+
+            // Pagination
+            ("Pagination: Page 1, 2 per page", () => Cms.Content<CmsExampleModel>(CollectionName).GetPage(1).GetPerPage(2)),
+            ("Pagination: Page 2, 2 per page", () => Cms.Content<CmsExampleModel>(CollectionName).GetPage(2).GetPerPage(2)),
         };
     }
 
+    private UILabel _titleLabel = null!;
+    private UIButton _btnApply = null!;
+    private UIButton _btnSearch = null!;
+    private UIProgressView _progressBar = null!;
+
     private void SetupUI()
     {
-        // Search Bar
-        _searchBar = new UISearchBar
+        // Title
+        _titleLabel = new UILabel
         {
-            Placeholder = "Search term...",
-            Delegate = this,
+            Text = "CMS Query Builder",
+            Font = UIFont.BoldSystemFontOfSize(20),
+            TextAlignment = UITextAlignment.Center,
             TranslatesAutoresizingMaskIntoConstraints = false
         };
 
-        // Get All Button
-        _btnGetAll = UIButton.FromType(UIButtonType.System);
-        _btnGetAll.SetTitle("Get All List", UIControlState.Normal);
-        _btnGetAll.TranslatesAutoresizingMaskIntoConstraints = false;
-        _btnGetAll.TouchUpInside += async (s, e) =>
-        {
-            await Cms.ClearCache(CollectionName);
-            await LoadResults(Cms.Content<CmsExampleModel>(CollectionName));
-        };
-
-        // Filter Menu Button
+        // Filter picker (button with menu) + Apply
         _btnFilter = UIButton.FromType(UIButtonType.System);
-        _btnFilter.SetTitle("Filters 🔽", UIControlState.Normal);
+        _btnFilter.SetTitle("Select a filter...", UIControlState.Normal);
+        _btnFilter.HorizontalAlignment = UIControlContentHorizontalAlignment.Left;
         _btnFilter.TranslatesAutoresizingMaskIntoConstraints = false;
+        _btnFilter.Layer.BorderColor = UIColor.SystemGray4.CGColor;
+        _btnFilter.Layer.BorderWidth = 1;
+        _btnFilter.Layer.CornerRadius = 8;
+        _btnFilter.ContentEdgeInsets = new UIEdgeInsets(0, 12, 0, 12);
+
         if (OperatingSystem.IsIOSVersionAtLeast(14))
         {
-            var actions = _cmsFilters.Select(f => UIAction.Create(f.Label, null, null, action =>
+            var actions = _cmsFilters.Select((f, idx) => UIAction.Create(f.Label, null, null, action =>
             {
-                _ = LoadResults(f.Build());
+                _selectedFilterIndex = idx;
+                _btnFilter.SetTitle(f.Label, UIControlState.Normal);
             })).ToArray();
             _btnFilter.Menu = UIMenu.Create(string.Empty, actions);
             _btnFilter.ShowsMenuAsPrimaryAction = true;
         }
+
+        _btnApply = UIButton.FromType(UIButtonType.System);
+        _btnApply.SetTitle("Apply", UIControlState.Normal);
+        _btnApply.BackgroundColor = UIColor.SystemBlue;
+        _btnApply.SetTitleColor(UIColor.White, UIControlState.Normal);
+        _btnApply.Layer.CornerRadius = 8;
+        _btnApply.TranslatesAutoresizingMaskIntoConstraints = false;
+        _btnApply.TouchUpInside += async (s, e) =>
+        {
+            if (_selectedFilterIndex < 0 || _selectedFilterIndex >= _cmsFilters.Count)
+            {
+                ShowAlert("Info", "Please select a filter first.");
+                return;
+            }
+            await LoadResults(_cmsFilters[_selectedFilterIndex].Build());
+        };
+
+        // Search bar + Search button
+        _searchBar = new UISearchBar
+        {
+            Placeholder = "Search term...",
+            SearchBarStyle = UISearchBarStyle.Minimal,
+            TranslatesAutoresizingMaskIntoConstraints = false
+        };
+
+        _btnSearch = UIButton.FromType(UIButtonType.System);
+        _btnSearch.SetTitle("Search", UIControlState.Normal);
+        _btnSearch.BackgroundColor = UIColor.SystemBlue;
+        _btnSearch.SetTitleColor(UIColor.White, UIControlState.Normal);
+        _btnSearch.Layer.CornerRadius = 8;
+        _btnSearch.TranslatesAutoresizingMaskIntoConstraints = false;
+        _btnSearch.TouchUpInside += async (s, e) =>
+        {
+            _searchBar.ResignFirstResponder();
+            var term = _searchBar.Text?.Trim();
+            if (!string.IsNullOrEmpty(term))
+                await LoadResults(Cms.Content<CmsExampleModel>(CollectionName).Search(term));
+        };
+
+        // Get All List button
+        _btnGetAll = UIButton.FromType(UIButtonType.System);
+        _btnGetAll.SetTitle("Get All List", UIControlState.Normal);
+        _btnGetAll.BackgroundColor = UIColor.SystemIndigo;
+        _btnGetAll.SetTitleColor(UIColor.White, UIControlState.Normal);
+        _btnGetAll.Layer.CornerRadius = 8;
+        _btnGetAll.TranslatesAutoresizingMaskIntoConstraints = false;
+        _btnGetAll.TouchUpInside += async (s, e) =>
+        {
+            await LoadResults(Cms.Content<CmsExampleModel>(CollectionName));
+        };
+
+        // Progress bar
+        _progressBar = new UIProgressView(UIProgressViewStyle.Bar)
+        {
+            TranslatesAutoresizingMaskIntoConstraints = false,
+            Hidden = true
+        };
 
         // Table View
         _tableView = new UITableView
         {
             TranslatesAutoresizingMaskIntoConstraints = false,
             RowHeight = UITableView.AutomaticDimension,
-            EstimatedRowHeight = 330f
+            EstimatedRowHeight = 140f,
+            SeparatorStyle = UITableViewCellSeparatorStyle.None
         };
         _tableView.RegisterClassForCellReuse(typeof(CmsCell), CmsCell.Key);
         _source = new CmsTableViewSource();
@@ -107,25 +187,69 @@ public class CmsViewController : UIViewController, IUISearchBarDelegate
             TranslatesAutoresizingMaskIntoConstraints = false
         };
 
-        View!.AddSubviews(_searchBar, _btnFilter, _btnGetAll, _tableView, _emptyLabel);
+        // Filter row container
+        var filterRow = new UIView { TranslatesAutoresizingMaskIntoConstraints = false };
+        filterRow.AddSubviews(_btnFilter, _btnApply);
 
-        // Constraints
+        // Search row container
+        var searchRow = new UIView { TranslatesAutoresizingMaskIntoConstraints = false };
+        searchRow.AddSubviews(_searchBar, _btnSearch);
+
+        View!.AddSubviews(_titleLabel, filterRow, searchRow, _btnGetAll, _progressBar, _tableView, _emptyLabel);
+
         var g = View.SafeAreaLayoutGuide;
         NSLayoutConstraint.ActivateConstraints(new[]
         {
-            _searchBar.TopAnchor.ConstraintEqualTo(g.TopAnchor),
-            _searchBar.LeadingAnchor.ConstraintEqualTo(g.LeadingAnchor),
-            _searchBar.TrailingAnchor.ConstraintEqualTo(g.TrailingAnchor),
+            // Title
+            _titleLabel.TopAnchor.ConstraintEqualTo(g.TopAnchor, 8),
+            _titleLabel.LeadingAnchor.ConstraintEqualTo(g.LeadingAnchor, 16),
+            _titleLabel.TrailingAnchor.ConstraintEqualTo(g.TrailingAnchor, -16),
 
-            _btnFilter.TopAnchor.ConstraintEqualTo(_searchBar.BottomAnchor, 8),
-            _btnFilter.LeadingAnchor.ConstraintEqualTo(g.LeadingAnchor, 16),
-            _btnFilter.HeightAnchor.ConstraintEqualTo(44),
+            // Filter row
+            filterRow.TopAnchor.ConstraintEqualTo(_titleLabel.BottomAnchor, 12),
+            filterRow.LeadingAnchor.ConstraintEqualTo(g.LeadingAnchor, 16),
+            filterRow.TrailingAnchor.ConstraintEqualTo(g.TrailingAnchor, -16),
+            filterRow.HeightAnchor.ConstraintEqualTo(44),
 
-            _btnGetAll.TopAnchor.ConstraintEqualTo(_searchBar.BottomAnchor, 8),
+            _btnFilter.TopAnchor.ConstraintEqualTo(filterRow.TopAnchor),
+            _btnFilter.LeadingAnchor.ConstraintEqualTo(filterRow.LeadingAnchor),
+            _btnFilter.TrailingAnchor.ConstraintEqualTo(_btnApply.LeadingAnchor, -8),
+            _btnFilter.BottomAnchor.ConstraintEqualTo(filterRow.BottomAnchor),
+
+            _btnApply.TopAnchor.ConstraintEqualTo(filterRow.TopAnchor),
+            _btnApply.TrailingAnchor.ConstraintEqualTo(filterRow.TrailingAnchor),
+            _btnApply.WidthAnchor.ConstraintEqualTo(80),
+            _btnApply.BottomAnchor.ConstraintEqualTo(filterRow.BottomAnchor),
+
+            // Search row
+            searchRow.TopAnchor.ConstraintEqualTo(filterRow.BottomAnchor, 8),
+            searchRow.LeadingAnchor.ConstraintEqualTo(g.LeadingAnchor, 8),
+            searchRow.TrailingAnchor.ConstraintEqualTo(g.TrailingAnchor, -16),
+            searchRow.HeightAnchor.ConstraintEqualTo(44),
+
+            _searchBar.TopAnchor.ConstraintEqualTo(searchRow.TopAnchor),
+            _searchBar.LeadingAnchor.ConstraintEqualTo(searchRow.LeadingAnchor),
+            _searchBar.TrailingAnchor.ConstraintEqualTo(_btnSearch.LeadingAnchor, -8),
+            _searchBar.BottomAnchor.ConstraintEqualTo(searchRow.BottomAnchor),
+
+            _btnSearch.TopAnchor.ConstraintEqualTo(searchRow.TopAnchor),
+            _btnSearch.TrailingAnchor.ConstraintEqualTo(searchRow.TrailingAnchor),
+            _btnSearch.WidthAnchor.ConstraintEqualTo(80),
+            _btnSearch.BottomAnchor.ConstraintEqualTo(searchRow.BottomAnchor),
+
+            // Get All List
+            _btnGetAll.TopAnchor.ConstraintEqualTo(searchRow.BottomAnchor, 10),
+            _btnGetAll.LeadingAnchor.ConstraintEqualTo(g.LeadingAnchor, 16),
             _btnGetAll.TrailingAnchor.ConstraintEqualTo(g.TrailingAnchor, -16),
             _btnGetAll.HeightAnchor.ConstraintEqualTo(44),
 
-            _tableView.TopAnchor.ConstraintEqualTo(_btnFilter.BottomAnchor, 8),
+            // Progress
+            _progressBar.TopAnchor.ConstraintEqualTo(_btnGetAll.BottomAnchor, 8),
+            _progressBar.LeadingAnchor.ConstraintEqualTo(g.LeadingAnchor, 16),
+            _progressBar.TrailingAnchor.ConstraintEqualTo(g.TrailingAnchor, -16),
+
+            // Table
+            _tableView.TopAnchor.ConstraintEqualTo(_progressBar.BottomAnchor, 4),
             _tableView.LeadingAnchor.ConstraintEqualTo(g.LeadingAnchor),
             _tableView.TrailingAnchor.ConstraintEqualTo(g.TrailingAnchor),
             _tableView.BottomAnchor.ConstraintEqualTo(g.BottomAnchor),
@@ -135,17 +259,16 @@ public class CmsViewController : UIViewController, IUISearchBarDelegate
         });
     }
 
-    [Export("searchBarSearchButtonClicked:")]
-    public void SearchButtonClicked(UISearchBar searchBar)
+    private void ShowAlert(string title, string message)
     {
-        searchBar.ResignFirstResponder();
-        var term = searchBar.Text?.Trim();
-        if (!string.IsNullOrEmpty(term))
-            _ = LoadResults(Cms.Content<CmsExampleModel>(CollectionName).Search(term));
+        var alert = UIAlertController.Create(title, message, UIAlertControllerStyle.Alert);
+        alert.AddAction(UIAlertAction.Create("OK", UIAlertActionStyle.Default, null));
+        PresentViewController(alert, true, null);
     }
 
     private async Task LoadResults(ICmsQueryBuilder<CmsExampleModel> query)
     {
+        InvokeOnMainThread(() => { _progressBar.Hidden = false; _progressBar.Progress = 0.5f; });
         try
         {
             var items = await query.GetListAsync();
@@ -154,15 +277,15 @@ public class CmsViewController : UIViewController, IUISearchBarDelegate
                 _source.UpdateData(items);
                 _tableView.ReloadData();
                 _emptyLabel.Hidden = items.Count != 0;
+                _progressBar.Hidden = true;
             });
         }
         catch (Exception ex)
         {
             InvokeOnMainThread(() =>
             {
-                var alert = UIAlertController.Create("Error", ex.Message, UIAlertControllerStyle.Alert);
-                alert.AddAction(UIAlertAction.Create("OK", UIAlertActionStyle.Default, null));
-                PresentViewController(alert, true, null);
+                _progressBar.Hidden = true;
+                ShowAlert("Error", ex.Message);
             });
         }
     }
@@ -192,6 +315,7 @@ public class CmsCell : UITableViewCell
     public static readonly NSString Key = new NSString(nameof(CmsCell));
 
     private UIImageView _imgProduct = null!;
+    private UIView _card = null!;
     private UILabel _lblProduct = null!;
     private UILabel _lblCategory = null!;
     private UILabel _lblDesc = null!;
@@ -205,6 +329,19 @@ public class CmsCell : UITableViewCell
     {
         SelectionStyle = UITableViewCellSelectionStyle.None;
 
+        // Card container
+        var card = new UIView
+        {
+            BackgroundColor = UIColor.SecondarySystemGroupedBackground,
+            TranslatesAutoresizingMaskIntoConstraints = false
+        };
+        card.Layer.CornerRadius = 12;
+        card.Layer.ShadowColor = UIColor.Black.CGColor;
+        card.Layer.ShadowOpacity = 0.1f;
+        card.Layer.ShadowOffset = new CoreGraphics.CGSize(0, 2);
+        card.Layer.ShadowRadius = 4;
+        _card = card;
+
         _imgProduct = new UIImageView
         {
             ContentMode = UIViewContentMode.ScaleAspectFill,
@@ -212,7 +349,7 @@ public class CmsCell : UITableViewCell
             BackgroundColor = UIColor.SystemGray5,
             TranslatesAutoresizingMaskIntoConstraints = false
         };
-        _imgProduct.Layer.CornerRadius = 0;
+        _imgProduct.Layer.CornerRadius = 8;
 
         _lblProduct = new UILabel { Font = UIFont.BoldSystemFontOfSize(16), TranslatesAutoresizingMaskIntoConstraints = false };
         _lblCategory = new UILabel { Font = UIFont.BoldSystemFontOfSize(11), TextColor = UIColor.SystemBlue, TranslatesAutoresizingMaskIntoConstraints = false, TextAlignment = UITextAlignment.Right };
@@ -224,42 +361,49 @@ public class CmsCell : UITableViewCell
         _lblSupport = new UILabel { Font = UIFont.SystemFontOfSize(11), TextColor = UIColor.LightGray, TranslatesAutoresizingMaskIntoConstraints = false };
         _lblIdAndDates = new UILabel { Font = UIFont.SystemFontOfSize(10), TextColor = UIColor.LightGray, Lines = 2, TranslatesAutoresizingMaskIntoConstraints = false, LineBreakMode = UILineBreakMode.MiddleTruncation };
 
-        ContentView.AddSubviews(_imgProduct, _lblProduct, _lblCategory, _lblDesc, _lblPrice, _lblSkuLine, _lblSupport, _lblIdAndDates);
+        ContentView.AddSubview(card);
+        card.AddSubviews(_imgProduct, _lblProduct, _lblCategory, _lblDesc, _lblPrice, _lblSkuLine, _lblSupport, _lblIdAndDates);
 
         NSLayoutConstraint.ActivateConstraints(new[]
         {
-            // Image — full width banner at top
-            _imgProduct.TopAnchor.ConstraintEqualTo(ContentView.TopAnchor),
-            _imgProduct.LeadingAnchor.ConstraintEqualTo(ContentView.LeadingAnchor),
-            _imgProduct.TrailingAnchor.ConstraintEqualTo(ContentView.TrailingAnchor),
-            _imgProduct.HeightAnchor.ConstraintEqualTo(150f),
+            // Card margins
+            card.TopAnchor.ConstraintEqualTo(ContentView.TopAnchor, 6),
+            card.LeadingAnchor.ConstraintEqualTo(ContentView.LeadingAnchor, 16),
+            card.TrailingAnchor.ConstraintEqualTo(ContentView.TrailingAnchor, -16),
+            card.BottomAnchor.ConstraintEqualTo(ContentView.BottomAnchor, -6),
 
-            // Product name + category below image
-            _lblProduct.TopAnchor.ConstraintEqualTo(_imgProduct.BottomAnchor, 12),
-            _lblProduct.LeadingAnchor.ConstraintEqualTo(ContentView.LeadingAnchor, 16),
+            // Thumbnail 80x80 left-aligned
+            _imgProduct.TopAnchor.ConstraintEqualTo(card.TopAnchor, 12),
+            _imgProduct.LeadingAnchor.ConstraintEqualTo(card.LeadingAnchor, 12),
+            _imgProduct.WidthAnchor.ConstraintEqualTo(80),
+            _imgProduct.HeightAnchor.ConstraintEqualTo(80),
+
+            // Product name + category right of image
+            _lblProduct.TopAnchor.ConstraintEqualTo(card.TopAnchor, 12),
+            _lblProduct.LeadingAnchor.ConstraintEqualTo(_imgProduct.TrailingAnchor, 16),
             _lblProduct.TrailingAnchor.ConstraintLessThanOrEqualTo(_lblCategory.LeadingAnchor, -8),
 
             _lblCategory.CenterYAnchor.ConstraintEqualTo(_lblProduct.CenterYAnchor),
-            _lblCategory.TrailingAnchor.ConstraintEqualTo(ContentView.TrailingAnchor, -16),
-            _lblCategory.WidthAnchor.ConstraintGreaterThanOrEqualTo(80),
+            _lblCategory.TrailingAnchor.ConstraintEqualTo(card.TrailingAnchor, -12),
 
-            _lblDesc.TopAnchor.ConstraintEqualTo(_lblProduct.BottomAnchor, 8),
-            _lblDesc.LeadingAnchor.ConstraintEqualTo(ContentView.LeadingAnchor, 16),
-            _lblDesc.TrailingAnchor.ConstraintEqualTo(ContentView.TrailingAnchor, -16),
+            _lblDesc.TopAnchor.ConstraintEqualTo(_lblProduct.BottomAnchor, 4),
+            _lblDesc.LeadingAnchor.ConstraintEqualTo(_imgProduct.TrailingAnchor, 16),
+            _lblDesc.TrailingAnchor.ConstraintEqualTo(card.TrailingAnchor, -12),
 
-            _lblSkuLine.TopAnchor.ConstraintEqualTo(_lblDesc.BottomAnchor, 8),
-            _lblSkuLine.LeadingAnchor.ConstraintEqualTo(ContentView.LeadingAnchor, 16),
+            // SKU + Price below image row
+            _lblSkuLine.TopAnchor.ConstraintEqualTo(_imgProduct.BottomAnchor, 8),
+            _lblSkuLine.LeadingAnchor.ConstraintEqualTo(card.LeadingAnchor, 12),
 
             _lblPrice.CenterYAnchor.ConstraintEqualTo(_lblSkuLine.CenterYAnchor),
             _lblPrice.LeadingAnchor.ConstraintEqualTo(_lblSkuLine.TrailingAnchor, 16),
 
-            _lblSupport.TopAnchor.ConstraintEqualTo(_lblSkuLine.BottomAnchor, 8),
-            _lblSupport.LeadingAnchor.ConstraintEqualTo(ContentView.LeadingAnchor, 16),
+            _lblSupport.TopAnchor.ConstraintEqualTo(_lblSkuLine.BottomAnchor, 4),
+            _lblSupport.LeadingAnchor.ConstraintEqualTo(card.LeadingAnchor, 12),
 
-            _lblIdAndDates.TopAnchor.ConstraintEqualTo(_lblSupport.BottomAnchor, 8),
-            _lblIdAndDates.LeadingAnchor.ConstraintEqualTo(ContentView.LeadingAnchor, 16),
-            _lblIdAndDates.TrailingAnchor.ConstraintEqualTo(ContentView.TrailingAnchor, -16),
-            _lblIdAndDates.BottomAnchor.ConstraintEqualTo(ContentView.BottomAnchor, -12),
+            _lblIdAndDates.TopAnchor.ConstraintEqualTo(_lblSupport.BottomAnchor, 4),
+            _lblIdAndDates.LeadingAnchor.ConstraintEqualTo(card.LeadingAnchor, 12),
+            _lblIdAndDates.TrailingAnchor.ConstraintEqualTo(card.TrailingAnchor, -12),
+            _lblIdAndDates.BottomAnchor.ConstraintEqualTo(card.BottomAnchor, -12),
         });
     }
 
@@ -268,10 +412,10 @@ public class CmsCell : UITableViewCell
         _lblProduct.Text = item.ProductName;
         _lblCategory.Text = item.Category?.Count > 0 ? $"🏷️ {string.Join(", ", item.Category)}" : "";
         _lblDesc.Text = item.Description;
-        _lblSkuLine.Text = $"{item.ItemSku}  |  Stock: {item.InStock}";
+        _lblSkuLine.Text = $"{item.ItemSku}    Stock: {item.InStock}";
         _lblPrice.Text = $"${item.Price:F2}";
         _lblSupport.Text = $"📧 {item.SupportEmail}";
-        _lblIdAndDates.Text = $"ID: {item.Id}\nCr: {item.CreatedAt:dd/MM/yy} | Pub: {item.PublishedAt:dd/MM/yy} | Upd: {item.UpdatedAt:dd/MM/yy}";
+        _lblIdAndDates.Text = $"ID: {item.Id}\nCr: {item.CreatedAt:dd/MM/yyyy}    Pub: {item.PublishedAt:dd/MM/yyyy}    Upd: {item.UpdatedAt:dd/MM/yyyy}";
 
         if (!string.IsNullOrWhiteSpace(item.ProductImageUrl))
             ImageUtils.LoadAsync(item.ProductImageUrl!, _imgProduct, item.Id ?? item.ProductImageUrl!);

--- a/samples/AppAmbit.App.Maui.Native.iOS/MainTabBarController.cs
+++ b/samples/AppAmbit.App.Maui.Native.iOS/MainTabBarController.cs
@@ -41,6 +41,13 @@ public class MainTabBarController : UITabBarController
              ? new UITabBarItem("Config", imgConfig, 2)
              : new UITabBarItem("Config", null, 2);
 
-        ViewControllers = new UIViewController[] { crashesNav, analyticsNav, configNav };
+        var cms = new CmsViewController();
+        var cmsNav = new UINavigationController(cms);
+        var imgCms = SysImg("doc.text.magnifyingglass");
+        cmsNav.TabBarItem = imgCms != null
+             ? new UITabBarItem("CMS", imgCms, 3)
+             : new UITabBarItem("CMS", null, 3);
+
+        ViewControllers = new UIViewController[] { crashesNav, analyticsNav, configNav, cmsNav };
     }
 }

--- a/samples/AppAmbit.App.Maui.Native.iOS/Models/CmsExampleModel.cs
+++ b/samples/AppAmbit.App.Maui.Native.iOS/Models/CmsExampleModel.cs
@@ -10,7 +10,7 @@ public class CmsExampleModel
     public decimal Price { get; set; }
 
     [JsonProperty("category")]
-    public string? Category { get; set; }
+    public List<string>? Category { get; set; }
 
     [JsonProperty("in_stock")]
     public bool InStock { get; set; }
@@ -29,6 +29,9 @@ public class CmsExampleModel
 
     [JsonProperty("product_image")]
     public string? ProductImage { get; set; }
+
+    [JsonProperty("product_image_url")]
+    public string? ProductImageUrl { get; set; }
 
     [JsonProperty("support_email")]
     public string? SupportEmail { get; set; }

--- a/samples/AppAmbit.App.Maui.Native.iOS/Models/CmsExampleModel.cs
+++ b/samples/AppAmbit.App.Maui.Native.iOS/Models/CmsExampleModel.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace AppAmbitTestingiOS.Models;
+
+public class CmsExampleModel
+{
+    [JsonProperty("price")]
+    public decimal Price { get; set; }
+
+    [JsonProperty("category")]
+    public string? Category { get; set; }
+
+    [JsonProperty("in_stock")]
+    public bool InStock { get; set; }
+
+    [JsonProperty("item_sku")]
+    public string? ItemSku { get; set; }
+
+    [JsonProperty("entry_date")]
+    public string? EntryDate { get; set; }
+
+    [JsonProperty("description")]
+    public string? Description { get; set; }
+
+    [JsonProperty("product_name")]
+    public string? ProductName { get; set; }
+
+    [JsonProperty("product_image")]
+    public string? ProductImage { get; set; }
+
+    [JsonProperty("support_email")]
+    public string? SupportEmail { get; set; }
+
+    [JsonProperty("technical_specs")]
+    public Dictionary<string, string>? TechnicalSpecs { get; set; }
+
+    [JsonProperty("id")]
+    public string? Id { get; set; }
+
+    [JsonProperty("published_at")]
+    public DateTimeOffset PublishedAt { get; set; }
+
+    [JsonProperty("created_at")]
+    public DateTimeOffset CreatedAt { get; set; }
+
+    [JsonProperty("updated_at")]
+    public DateTimeOffset UpdatedAt { get; set; }
+}

--- a/samples/AppAmbit.App.Maui.Native.iOS/Utils/ImageUtils.cs
+++ b/samples/AppAmbit.App.Maui.Native.iOS/Utils/ImageUtils.cs
@@ -1,0 +1,35 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using Foundation;
+using UIKit;
+
+namespace AppAmbitTestingiOS.Utils;
+
+internal static class ImageUtils
+{
+    private static readonly HttpClient _http = new();
+
+    /// <summary>
+    /// Loads an image from <paramref name="url"/> on a background thread and sets it on
+    /// <paramref name="imageView"/> on the UI thread. Uses <paramref name="tag"/> to discard
+    /// results that arrive after the cell has been recycled to a different item.
+    /// </summary>
+    internal static void LoadAsync(string url, UIImageView imageView, object tag)
+    {
+        imageView.Image = null;
+        imageView.AccessibilityIdentifier = tag.ToString();
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                var bytes = await _http.GetByteArrayAsync(url);
+                var data = NSData.FromArray(bytes);
+                var img = UIImage.LoadFromData(data);
+                if (img != null && imageView.AccessibilityIdentifier == tag.ToString())
+                    imageView.InvokeOnMainThread(() => imageView.Image = img);
+            }
+            catch { }
+        });
+    }
+}

--- a/samples/AppAmbit.App.Maui/AppShell.xaml
+++ b/samples/AppAmbit.App.Maui/AppShell.xaml
@@ -23,5 +23,9 @@
         <ShellContent Title="RemoteConfig"
               ContentTemplate="{DataTemplate local:RemoteConfigPage}"
               Route="RemoteConfigPage" />
+
+        <ShellContent Title="CMS"
+              ContentTemplate="{DataTemplate local:CmsPage}"
+              Route="CmsPage" />
     </TabBar>
 </Shell>

--- a/samples/AppAmbit.App.Maui/CmsPage.xaml
+++ b/samples/AppAmbit.App.Maui/CmsPage.xaml
@@ -45,25 +45,51 @@
         <CollectionView Grid.Row="1" x:Name="ResultsList" Margin="16,0,16,16">
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="models:CmsExampleModel">
-                    <Frame Margin="0,4" Padding="12" HasShadow="True"
-                           BackgroundColor="{AppThemeBinding Light=White, Dark=Black}">
-                        <VerticalStackLayout Spacing="4">
-                            <Label Text="{Binding ProductName}"
-                                   FontAttributes="Bold" FontSize="14"
-                                   TextColor="{AppThemeBinding Light=Black, Dark=White}" />
-                            <Label Text="{Binding Description}"
-                                   FontSize="12" TextColor="Gray"
-                                   MaxLines="2" LineBreakMode="TailTruncation" />
-                            <HorizontalStackLayout Spacing="12">
-                                <Label Text="{Binding ItemSku}"
-                                       FontSize="11"
-                                       TextColor="{AppThemeBinding Light=DimGray, Dark=LightGray}" />
-                                <Label Text="{Binding Price, StringFormat='${0:F2}'}"
-                                       FontSize="11" TextColor="ForestGreen" FontAttributes="Bold" />
-                                <Label Text="{Binding PublishedAt, StringFormat='Published: {0:d}'}"
-                                       FontSize="11" TextColor="DimGray" />
-                            </HorizontalStackLayout>
-                        </VerticalStackLayout>
+                    <Frame Margin="0,6" Padding="12" HasShadow="True" BorderColor="Transparent" CornerRadius="12"
+                           BackgroundColor="{AppThemeBinding Light=White, Dark=#1E1E1E}">
+                        <Grid ColumnDefinitions="80,*" ColumnSpacing="16">
+                            
+                            <!-- Image -->
+                            <Frame Grid.Column="0" HeightRequest="80" WidthRequest="80" Padding="0" CornerRadius="8" IsClippedToBounds="True" BackgroundColor="{AppThemeBinding Light=#ECEFF1, Dark=#263238}" VerticalOptions="Start" BorderColor="Transparent">
+                                <Image Source="{Binding ProductImage}" Aspect="AspectFill" />
+                            </Frame>
+
+                            <VerticalStackLayout Grid.Column="1" Spacing="6">
+                                
+                                <!-- Header: Name & Category -->
+                                <Grid ColumnDefinitions="*, Auto" ColumnSpacing="8">
+                                    <Label Grid.Column="0" Text="{Binding ProductName}" FontAttributes="Bold" FontSize="16" TextColor="{AppThemeBinding Light=#212121, Dark=White}" VerticalOptions="Center" LineBreakMode="TailTruncation" />
+                                    <!-- Using Label directly to avoid empty frames when Category is null -->
+                                    <Label Grid.Column="1" Text="{Binding Category, StringFormat='🏷️ {0}'}" FontSize="11" TextColor="{AppThemeBinding Light=#1976D2, Dark=#64B5F6}" FontAttributes="Bold" VerticalOptions="Center" />
+                                </Grid>
+                                
+                                <!-- Description -->
+                                <Label Text="{Binding Description}" FontSize="13" TextColor="{AppThemeBinding Light=#757575, Dark=#BDBDBD}" MaxLines="2" LineBreakMode="TailTruncation" />
+                                
+                                <!-- Meta Grid (SKU, Price, Stock) -->
+                                <FlexLayout Wrap="Wrap" JustifyContent="SpaceBetween" AlignItems="Center">
+                                    <Label Text="{Binding ItemSku}" FontSize="12" TextColor="{AppThemeBinding Light=#9E9E9E, Dark=#9E9E9E}" />
+                                    <Label Text="{Binding Price, StringFormat='${0:F2}'}" FontSize="13" TextColor="#4CAF50" FontAttributes="Bold" Margin="8,0" />
+                                    <Label Text="{Binding InStock, StringFormat='Stock: {0}'}" FontSize="12" TextColor="{AppThemeBinding Light=#607D8B, Dark=#B0BEC5}" />
+                                </FlexLayout>
+
+                                <!-- Support Email -->
+                                <Label Text="{Binding SupportEmail, StringFormat='📧 {0}'}" FontSize="11" TextColor="{AppThemeBinding Light=#757575, Dark=#9E9E9E}" LineBreakMode="TailTruncation" />
+
+                                <BoxView HeightRequest="1" Color="{AppThemeBinding Light=#EEEEEE, Dark=#333333}" Margin="0,4" />
+                                
+                                <!-- ID -->
+                                <Label Text="{Binding Id, StringFormat='ID: {0}'}" FontSize="10" TextColor="{AppThemeBinding Light=#BDBDBD, Dark=#616161}" LineBreakMode="MiddleTruncation" />
+                                
+                                <!-- Dates in a responsive Grid -->
+                                <Grid ColumnDefinitions="*, *" RowDefinitions="Auto, Auto" ColumnSpacing="8" RowSpacing="2">
+                                    <Label Grid.Row="0" Grid.Column="0" Text="{Binding CreatedAt, StringFormat='Cr: {0:dd/MM/yyyy}'}" FontSize="10" TextColor="{AppThemeBinding Light=#9E9E9E, Dark=#757575}" />
+                                    <Label Grid.Row="0" Grid.Column="1" Text="{Binding PublishedAt, StringFormat='Pub: {0:dd/MM/yyyy}'}" FontSize="10" TextColor="{AppThemeBinding Light=#9E9E9E, Dark=#757575}" />
+                                    <Label Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Text="{Binding UpdatedAt, StringFormat='Upd: {0:dd/MM/yyyy}'}" FontSize="10" TextColor="{AppThemeBinding Light=#9E9E9E, Dark=#757575}" />
+                                </Grid>
+                                
+                            </VerticalStackLayout>
+                        </Grid>
                     </Frame>
                 </DataTemplate>
             </CollectionView.ItemTemplate>

--- a/samples/AppAmbit.App.Maui/CmsPage.xaml
+++ b/samples/AppAmbit.App.Maui/CmsPage.xaml
@@ -3,10 +3,15 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:AppAmbitTestingApp"
              xmlns:models="clr-namespace:AppAmbitTestingApp.Models"
+             xmlns:utils="clr-namespace:AppAmbitTestingApp.Utils"
              x:Class="AppAmbitTestingApp.CmsPage"
              Title="CMS Showcase">
 
-    <Grid RowDefinitions="Auto,*">
+    <ContentPage.Resources>
+        <utils:ListToStringConverter x:Key="ListToStringConverter" />
+    </ContentPage.Resources>
+
+    <Grid RowDefinitions="Auto,Auto,*">
 
         <!-- Controls -->
         <VerticalStackLayout Grid.Row="0" Padding="16" Spacing="10">
@@ -41,8 +46,15 @@
 
         </VerticalStackLayout>
 
+        <ProgressBar Grid.Row="1"
+                     x:Name="LoadingBar"
+                     IsVisible="False"
+                     IsIndeterminate="True"
+                     HeightRequest="3"
+                     Margin="16,0,16,8" />
+
         <!-- Results -->
-        <CollectionView Grid.Row="1" x:Name="ResultsList" Margin="16,0,16,16">
+        <CollectionView Grid.Row="2" x:Name="ResultsList" Margin="16,0,16,16">
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="models:CmsExampleModel">
                     <Frame Margin="0,6" Padding="12" HasShadow="True" BorderColor="Transparent" CornerRadius="12"
@@ -51,7 +63,7 @@
                             
                             <!-- Image -->
                             <Frame Grid.Column="0" HeightRequest="80" WidthRequest="80" Padding="0" CornerRadius="8" IsClippedToBounds="True" BackgroundColor="{AppThemeBinding Light=#ECEFF1, Dark=#263238}" VerticalOptions="Start" BorderColor="Transparent">
-                                <Image Source="{Binding ProductImage}" Aspect="AspectFill" />
+                                <Image Source="{Binding ProductImageUrl}" Aspect="AspectFill" />
                             </Frame>
 
                             <VerticalStackLayout Grid.Column="1" Spacing="6">
@@ -60,7 +72,7 @@
                                 <Grid ColumnDefinitions="*, Auto" ColumnSpacing="8">
                                     <Label Grid.Column="0" Text="{Binding ProductName}" FontAttributes="Bold" FontSize="16" TextColor="{AppThemeBinding Light=#212121, Dark=White}" VerticalOptions="Center" LineBreakMode="TailTruncation" />
                                     <!-- Using Label directly to avoid empty frames when Category is null -->
-                                    <Label Grid.Column="1" Text="{Binding Category, StringFormat='🏷️ {0}'}" FontSize="11" TextColor="{AppThemeBinding Light=#1976D2, Dark=#64B5F6}" FontAttributes="Bold" VerticalOptions="Center" />
+                                    <Label Grid.Column="1" Text="{Binding Category, Converter={StaticResource ListToStringConverter}, StringFormat='🏷️ {0}'}" FontSize="11" TextColor="{AppThemeBinding Light=#1976D2, Dark=#64B5F6}" FontAttributes="Bold" VerticalOptions="Center" />
                                 </Grid>
                                 
                                 <!-- Description -->

--- a/samples/AppAmbit.App.Maui/CmsPage.xaml
+++ b/samples/AppAmbit.App.Maui/CmsPage.xaml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:AppAmbitTestingApp"
+             xmlns:models="clr-namespace:AppAmbitTestingApp.Models"
+             x:Class="AppAmbitTestingApp.CmsPage"
+             Title="CMS Showcase">
+
+    <Grid RowDefinitions="Auto,*">
+
+        <!-- Controls -->
+        <VerticalStackLayout Grid.Row="0" Padding="16" Spacing="10">
+
+            <Label Text="CMS Query Builder"
+                   FontSize="20" FontAttributes="Bold"
+                   HorizontalOptions="Center" />
+
+            <!-- Filter Picker + Apply button -->
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                <Picker x:Name="FilterPicker"
+                        Title="Select a filter..."
+                        HorizontalOptions="FillAndExpand" />
+                <Button Text="Apply"
+                        Clicked="OnApplyFilterClicked"
+                        HorizontalOptions="End" />
+            </Grid>
+
+            <!-- Search -->
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                <Entry x:Name="SearchEntry"
+                       Placeholder="Search term..."
+                       HorizontalOptions="FillAndExpand" />
+                <Button Text="Search"
+                        Clicked="OnSearchClicked"
+                        HorizontalOptions="End" />
+            </Grid>
+
+            <!-- Get All / Reset -->
+            <Button Text="Get All List"
+                    Clicked="OnFetchListClicked" />
+
+        </VerticalStackLayout>
+
+        <!-- Results -->
+        <CollectionView Grid.Row="1" x:Name="ResultsList" Margin="16,0,16,16">
+            <CollectionView.ItemTemplate>
+                <DataTemplate x:DataType="models:CmsExampleModel">
+                    <Frame Margin="0,4" Padding="12" HasShadow="True"
+                           BackgroundColor="{AppThemeBinding Light=White, Dark=Black}">
+                        <VerticalStackLayout Spacing="4">
+                            <Label Text="{Binding ProductName}"
+                                   FontAttributes="Bold" FontSize="14"
+                                   TextColor="{AppThemeBinding Light=Black, Dark=White}" />
+                            <Label Text="{Binding Description}"
+                                   FontSize="12" TextColor="Gray"
+                                   MaxLines="2" LineBreakMode="TailTruncation" />
+                            <HorizontalStackLayout Spacing="12">
+                                <Label Text="{Binding ItemSku}"
+                                       FontSize="11"
+                                       TextColor="{AppThemeBinding Light=DimGray, Dark=LightGray}" />
+                                <Label Text="{Binding Price, StringFormat='${0:F2}'}"
+                                       FontSize="11" TextColor="ForestGreen" FontAttributes="Bold" />
+                                <Label Text="{Binding PublishedAt, StringFormat='Published: {0:d}'}"
+                                       FontSize="11" TextColor="DimGray" />
+                            </HorizontalStackLayout>
+                        </VerticalStackLayout>
+                    </Frame>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+
+    </Grid>
+</ContentPage>

--- a/samples/AppAmbit.App.Maui/CmsPage.xaml.cs
+++ b/samples/AppAmbit.App.Maui/CmsPage.xaml.cs
@@ -9,7 +9,7 @@ public partial class CmsPage : ContentPage
     private const string Collection = "tech_inventory";
 
     // Filter definitions: label shown in Picker → factory that builds the query
-    private readonly List<(string Label, Func<CmsQueryBuilder<CmsExampleModel>> Build)> _filters;
+    private readonly List<(string Label, Func<ICmsQueryBuilder<CmsExampleModel>> Build)> _filters;
 
     public CmsPage()
     {
@@ -57,9 +57,9 @@ public partial class CmsPage : ContentPage
 
             // Pagination
             ("Pagination: Page 1, 2 per page",
-                () => Cms.For<CmsExampleModel>(Collection).SetPage(1).SetPerPage(2)),
+                () => Cms.For<CmsExampleModel>(Collection).GetPage(1).GetPerPage(2)),
             ("Pagination: Page 2, 2 per page",
-                () => Cms.For<CmsExampleModel>(Collection).SetPage(2).SetPerPage(2)),
+                () => Cms.For<CmsExampleModel>(Collection).GetPage(2).GetPerPage(2)),
         };
 
         FilterPicker.ItemsSource = _filters.Select(f => f.Label).ToList();
@@ -90,7 +90,7 @@ public partial class CmsPage : ContentPage
             await LoadResults(Cms.For<CmsExampleModel>(Collection).Search(term));
     }
 
-    private async Task LoadResults(CmsQueryBuilder<CmsExampleModel> query)
+    private async Task LoadResults(ICmsQueryBuilder<CmsExampleModel> query)
     {
         try
         {

--- a/samples/AppAmbit.App.Maui/CmsPage.xaml.cs
+++ b/samples/AppAmbit.App.Maui/CmsPage.xaml.cs
@@ -1,0 +1,112 @@
+using AppAmbit;
+using AppAmbitTestingApp.Models;
+
+
+namespace AppAmbitTestingApp;
+
+public partial class CmsPage : ContentPage
+{
+    private const string Collection = "tech_inventory";
+
+    // Filter definitions: label shown in Picker → factory that builds the query
+    private readonly List<(string Label, Func<CmsQueryBuilder<CmsExampleModel>> Build)> _filters;
+
+    public CmsPage()
+    {
+        InitializeComponent();
+
+        _filters = new()
+        {
+            // Equality
+            ("Equals: item_sku = TEC-02",
+                () => Cms.For<CmsExampleModel>(Collection).Equals("item_sku", "TEC-02")),
+            ("Not Equals: item_sku ≠ TEC-02",
+                () => Cms.For<CmsExampleModel>(Collection).NotEquals("item_sku", "TEC-02")),
+
+            // Text matching
+            ("Contains: product_name contains 'Pro'",
+                () => Cms.For<CmsExampleModel>(Collection).Contains("product_name", "Pro")),
+            ("Starts With: item_sku starts with 'TEC'",
+                () => Cms.For<CmsExampleModel>(Collection).StartsWith("item_sku", "TEC")),
+
+            // List membership
+            ("In List: item_sku in [TEC-01, TEC-02]",
+                () => Cms.For<CmsExampleModel>(Collection).InList("item_sku", new[] { "TEC-01", "TEC-02" })),
+            ("Not In List: item_sku not in [TEC-01, TEC-02]",
+                () => Cms.For<CmsExampleModel>(Collection).NotInList("item_sku", new[] { "TEC-01", "TEC-02" })),
+
+            // Numeric comparisons
+            ("Greater Than: price > 500",
+                () => Cms.For<CmsExampleModel>(Collection).GreaterThan("price", 500)),
+            ("Greater Or Equal: price >= 500",
+                () => Cms.For<CmsExampleModel>(Collection).GreaterThanOrEqual("price", 500)),
+            ("Less Than: price < 500",
+                () => Cms.For<CmsExampleModel>(Collection).LessThan("price", 500)),
+            ("Less Or Equal: price <= 500",
+                () => Cms.For<CmsExampleModel>(Collection).LessThanOrEqual("price", 500)),
+
+            // Sorting
+            ("Order By price ASC",
+                () => Cms.For<CmsExampleModel>(Collection).OrderByAscending("price")),
+            ("Order By price DESC",
+                () => Cms.For<CmsExampleModel>(Collection).OrderByDescending("price")),
+
+            // Pagination
+            ("Pagination: Page 1, 2 per page",
+                () => Cms.For<CmsExampleModel>(Collection).SetPage(1).SetPerPage(2)),
+            ("Pagination: Page 2, 2 per page",
+                () => Cms.For<CmsExampleModel>(Collection).SetPage(2).SetPerPage(2)),
+        };
+
+        FilterPicker.ItemsSource = _filters.Select(f => f.Label).ToList();
+    }
+
+    // Get all without filters
+    private async void OnFetchListClicked(object sender, EventArgs e)
+    {
+        //await LoadResults(Cms.For<CmsExampleModel>("sistema_de_gestion_de_propiedades_de_una_marinaclub_nautico"));
+        Cms.Clear("sistema_de_gestion_de_propiedades_de_una_marinaclub_nautico");
+        await LoadResults(Cms.For<CmsExampleModel>(Collection));
+    }
+
+    // Apply selected filter from Picker
+    private async void OnApplyFilterClicked(object sender, EventArgs e)
+    {
+        if (FilterPicker.SelectedIndex < 0)
+        {
+            await DisplayAlert("Info", "Please select a filter first.", "OK");
+            return;
+        }
+        var query = _filters[FilterPicker.SelectedIndex].Build();
+        await LoadResults(query);
+    }
+
+    // Full-text search
+    private async void OnSearchClicked(object sender, EventArgs e)
+    {
+        var term = SearchEntry.Text?.Trim();
+        if (!string.IsNullOrWhiteSpace(term))
+            await LoadResults(Cms.For<CmsExampleModel>(Collection).Search(term));
+    }
+
+    private async Task LoadResults(CmsQueryBuilder<CmsExampleModel> query)
+    {
+        try
+        {
+            var items = await query.GetListAsync();
+
+            MainThread.BeginInvokeOnMainThread(() =>
+            {
+                ResultsList.ItemsSource = null;
+                ResultsList.ItemsSource = items;
+            });
+
+            if (items.Count == 0)
+                await DisplayAlert("Info", "No entries found. Cache may be empty — try again in a few seconds.", "OK");
+        }
+        catch (Exception ex)
+        {
+            await DisplayAlert("Error", ex.Message, "OK");
+        }
+    }
+}

--- a/samples/AppAmbit.App.Maui/CmsPage.xaml.cs
+++ b/samples/AppAmbit.App.Maui/CmsPage.xaml.cs
@@ -22,8 +22,8 @@ public partial class CmsPage : ContentPage
                 () => Cms.Content<CmsExampleModel>(Collection).Equals("item_sku", "TEC-02")),
             ("Not Equals: item_sku ≠ TEC-02",
                 () => Cms.Content<CmsExampleModel>(Collection).NotEquals("item_sku", "TEC-02")),
-            ("Equals: category = Electronics",
-                () => Cms.Content<CmsExampleModel>(Collection).Equals("category", "Electronics")),
+            ("In List: category = Cat 1",
+                () => Cms.Content<CmsExampleModel>(Collection).InList("category", new[] { "Cat 1" })),
             ("Boolean: in_stock = true",
                 () => Cms.Content<CmsExampleModel>(Collection).Equals("in_stock", "true")),
 
@@ -50,6 +50,10 @@ public partial class CmsPage : ContentPage
                 () => Cms.Content<CmsExampleModel>(Collection).LessThanOrEqual("price", 500)),
 
             // Sorting
+            ("Order By product_name ASC",
+                () => Cms.Content<CmsExampleModel>(Collection).OrderByAscending("product_name")),
+            ("Order By product_name DESC",
+                () => Cms.Content<CmsExampleModel>(Collection).OrderByDescending("product_name")),
             ("Order By price ASC",
                 () => Cms.Content<CmsExampleModel>(Collection).OrderByAscending("price")),
             ("Order By price DESC",

--- a/samples/AppAmbit.App.Maui/CmsPage.xaml.cs
+++ b/samples/AppAmbit.App.Maui/CmsPage.xaml.cs
@@ -22,6 +22,10 @@ public partial class CmsPage : ContentPage
                 () => Cms.For<CmsExampleModel>(Collection).Equals("item_sku", "TEC-02")),
             ("Not Equals: item_sku ≠ TEC-02",
                 () => Cms.For<CmsExampleModel>(Collection).NotEquals("item_sku", "TEC-02")),
+            ("Equals: category = Electronics",
+                () => Cms.For<CmsExampleModel>(Collection).Equals("category", "Electronics")),
+            ("Boolean: in_stock = true",
+                () => Cms.For<CmsExampleModel>(Collection).Equals("in_stock", "true")),
 
             // Text matching
             ("Contains: product_name contains 'Pro'",
@@ -61,11 +65,8 @@ public partial class CmsPage : ContentPage
         FilterPicker.ItemsSource = _filters.Select(f => f.Label).ToList();
     }
 
-    // Get all without filters
     private async void OnFetchListClicked(object sender, EventArgs e)
     {
-        //await LoadResults(Cms.For<CmsExampleModel>("sistema_de_gestion_de_propiedades_de_una_marinaclub_nautico"));
-        Cms.Clear("sistema_de_gestion_de_propiedades_de_una_marinaclub_nautico");
         await LoadResults(Cms.For<CmsExampleModel>(Collection));
     }
 

--- a/samples/AppAmbit.App.Maui/CmsPage.xaml.cs
+++ b/samples/AppAmbit.App.Maui/CmsPage.xaml.cs
@@ -19,47 +19,47 @@ public partial class CmsPage : ContentPage
         {
             // Equality
             ("Equals: item_sku = TEC-02",
-                () => Cms.For<CmsExampleModel>(Collection).Equals("item_sku", "TEC-02")),
+                () => Cms.Content<CmsExampleModel>(Collection).Equals("item_sku", "TEC-02")),
             ("Not Equals: item_sku ≠ TEC-02",
-                () => Cms.For<CmsExampleModel>(Collection).NotEquals("item_sku", "TEC-02")),
+                () => Cms.Content<CmsExampleModel>(Collection).NotEquals("item_sku", "TEC-02")),
             ("Equals: category = Electronics",
-                () => Cms.For<CmsExampleModel>(Collection).Equals("category", "Electronics")),
+                () => Cms.Content<CmsExampleModel>(Collection).Equals("category", "Electronics")),
             ("Boolean: in_stock = true",
-                () => Cms.For<CmsExampleModel>(Collection).Equals("in_stock", "true")),
+                () => Cms.Content<CmsExampleModel>(Collection).Equals("in_stock", "true")),
 
             // Text matching
             ("Contains: product_name contains 'Pro'",
-                () => Cms.For<CmsExampleModel>(Collection).Contains("product_name", "Pro")),
+                () => Cms.Content<CmsExampleModel>(Collection).Contains("product_name", "Pro")),
             ("Starts With: item_sku starts with 'TEC'",
-                () => Cms.For<CmsExampleModel>(Collection).StartsWith("item_sku", "TEC")),
+                () => Cms.Content<CmsExampleModel>(Collection).StartsWith("item_sku", "TEC")),
 
             // List membership
             ("In List: item_sku in [TEC-01, TEC-02]",
-                () => Cms.For<CmsExampleModel>(Collection).InList("item_sku", new[] { "TEC-01", "TEC-02" })),
+                () => Cms.Content<CmsExampleModel>(Collection).InList("item_sku", new[] { "TEC-01", "TEC-02" })),
             ("Not In List: item_sku not in [TEC-01, TEC-02]",
-                () => Cms.For<CmsExampleModel>(Collection).NotInList("item_sku", new[] { "TEC-01", "TEC-02" })),
+                () => Cms.Content<CmsExampleModel>(Collection).NotInList("item_sku", new[] { "TEC-01", "TEC-02" })),
 
             // Numeric comparisons
             ("Greater Than: price > 500",
-                () => Cms.For<CmsExampleModel>(Collection).GreaterThan("price", 500)),
+                () => Cms.Content<CmsExampleModel>(Collection).GreaterThan("price", 500)),
             ("Greater Or Equal: price >= 500",
-                () => Cms.For<CmsExampleModel>(Collection).GreaterThanOrEqual("price", 500)),
+                () => Cms.Content<CmsExampleModel>(Collection).GreaterThanOrEqual("price", 500)),
             ("Less Than: price < 500",
-                () => Cms.For<CmsExampleModel>(Collection).LessThan("price", 500)),
+                () => Cms.Content<CmsExampleModel>(Collection).LessThan("price", 500)),
             ("Less Or Equal: price <= 500",
-                () => Cms.For<CmsExampleModel>(Collection).LessThanOrEqual("price", 500)),
+                () => Cms.Content<CmsExampleModel>(Collection).LessThanOrEqual("price", 500)),
 
             // Sorting
             ("Order By price ASC",
-                () => Cms.For<CmsExampleModel>(Collection).OrderByAscending("price")),
+                () => Cms.Content<CmsExampleModel>(Collection).OrderByAscending("price")),
             ("Order By price DESC",
-                () => Cms.For<CmsExampleModel>(Collection).OrderByDescending("price")),
+                () => Cms.Content<CmsExampleModel>(Collection).OrderByDescending("price")),
 
             // Pagination
             ("Pagination: Page 1, 2 per page",
-                () => Cms.For<CmsExampleModel>(Collection).GetPage(1).GetPerPage(2)),
+                () => Cms.Content<CmsExampleModel>(Collection).GetPage(1).GetPerPage(2)),
             ("Pagination: Page 2, 2 per page",
-                () => Cms.For<CmsExampleModel>(Collection).GetPage(2).GetPerPage(2)),
+                () => Cms.Content<CmsExampleModel>(Collection).GetPage(2).GetPerPage(2)),
         };
 
         FilterPicker.ItemsSource = _filters.Select(f => f.Label).ToList();
@@ -67,7 +67,7 @@ public partial class CmsPage : ContentPage
 
     private async void OnFetchListClicked(object sender, EventArgs e)
     {
-        await LoadResults(Cms.For<CmsExampleModel>(Collection));
+        await LoadResults(Cms.Content<CmsExampleModel>(Collection));
     }
 
     // Apply selected filter from Picker
@@ -87,7 +87,7 @@ public partial class CmsPage : ContentPage
     {
         var term = SearchEntry.Text?.Trim();
         if (!string.IsNullOrWhiteSpace(term))
-            await LoadResults(Cms.For<CmsExampleModel>(Collection).Search(term));
+            await LoadResults(Cms.Content<CmsExampleModel>(Collection).Search(term));
     }
 
     private async Task LoadResults(ICmsQueryBuilder<CmsExampleModel> query)

--- a/samples/AppAmbit.App.Maui/CmsPage.xaml.cs
+++ b/samples/AppAmbit.App.Maui/CmsPage.xaml.cs
@@ -92,6 +92,7 @@ public partial class CmsPage : ContentPage
 
     private async Task LoadResults(ICmsQueryBuilder<CmsExampleModel> query)
     {
+        SetLoading(true);
         try
         {
             var items = await query.GetListAsync();
@@ -101,13 +102,22 @@ public partial class CmsPage : ContentPage
                 ResultsList.ItemsSource = null;
                 ResultsList.ItemsSource = items;
             });
-
-            if (items.Count == 0)
-                await DisplayAlert("Info", "No entries found. Cache may be empty — try again in a few seconds.", "OK");
         }
         catch (Exception ex)
         {
             await DisplayAlert("Error", ex.Message, "OK");
         }
+        finally
+        {
+            SetLoading(false);
+        }
+    }
+
+    private void SetLoading(bool isLoading)
+    {
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            LoadingBar.IsVisible = isLoading;
+        });
     }
 }

--- a/samples/AppAmbit.App.Maui/Models/CmsExampleModel.cs
+++ b/samples/AppAmbit.App.Maui/Models/CmsExampleModel.cs
@@ -1,0 +1,50 @@
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace AppAmbitTestingApp.Models
+{
+    public class CmsExampleModel
+    {
+        [JsonProperty("price")]
+        public decimal Price { get; set; }
+
+        [JsonProperty("category")]
+        public string Category { get; set; }
+
+        [JsonProperty("in_stock")]
+        public bool InStock { get; set; }
+
+        [JsonProperty("item_sku")]
+        public string ItemSku { get; set; }
+
+        [JsonProperty("entry_date")]
+        public string EntryDate { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("product_name")]
+        public string ProductName { get; set; }
+
+        [JsonProperty("product_image")]
+        public string ProductImage { get; set; }
+
+        [JsonProperty("support_email")]
+        public string SupportEmail { get; set; }
+
+        [JsonProperty("technical_specs")]
+        public Dictionary<string, string> TechnicalSpecs { get; set; }
+
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("published_at")]
+        public DateTimeOffset PublishedAt { get; set; }
+
+        [JsonProperty("created_at")]
+        public DateTimeOffset CreatedAt { get; set; }
+
+        [JsonProperty("updated_at")]
+        public DateTimeOffset UpdatedAt { get; set; }
+    }
+}

--- a/samples/AppAmbit.App.Maui/Models/CmsExampleModel.cs
+++ b/samples/AppAmbit.App.Maui/Models/CmsExampleModel.cs
@@ -9,7 +9,7 @@ namespace AppAmbitTestingApp.Models
         public decimal Price { get; set; }
 
         [JsonProperty("category")]
-        public string Category { get; set; }
+        public List<string>? Category { get; set; }
 
         [JsonProperty("in_stock")]
         public bool InStock { get; set; }
@@ -27,7 +27,10 @@ namespace AppAmbitTestingApp.Models
         public string ProductName { get; set; }
 
         [JsonProperty("product_image")]
-        public string ProductImage { get; set; }
+        public string? ProductImage { get; set; }
+
+        [JsonProperty("product_image_url")]
+        public string? ProductImageUrl { get; set; }
 
         [JsonProperty("support_email")]
         public string SupportEmail { get; set; }

--- a/samples/AppAmbit.App.Maui/Utils/ListToStringConverter.cs
+++ b/samples/AppAmbit.App.Maui/Utils/ListToStringConverter.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Globalization;
+using Microsoft.Maui.Controls;
+
+namespace AppAmbitTestingApp.Utils;
+
+public class ListToStringConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is IEnumerable<string> list)
+            return string.Join(", ", list);
+        return value?.ToString();
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/sdk/AppAmbit.Avalonia/Cms.cs
+++ b/sdk/AppAmbit.Avalonia/Cms.cs
@@ -1,0 +1,13 @@
+namespace AppAmbitAvalonia;
+
+public static class Cms
+{
+    public static AppAmbit.ICmsQueryBuilder<T> Content<T>(string contentType) where T : class
+        => AppAmbit.Cms.Content<T>(contentType);
+
+    public static Task ClearCache(string contentType)
+        => AppAmbit.Cms.ClearCache(contentType);
+
+    public static Task ClearAllCache()
+        => AppAmbit.Cms.ClearAllCache();
+}

--- a/sdk/AppAmbit/AppAmbitSdk.cs
+++ b/sdk/AppAmbit/AppAmbitSdk.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using AppAmbit.Services;
 using AppAmbit.Services.Interfaces;
 
@@ -15,6 +15,7 @@ public static class AppAmbitSdk
     private static bool _configuredByBuilder = false;
     private static bool _servicesReady = false;
     public static bool IsInitialized => _servicesReady;
+    internal static string? AppKey { get; private set; }
     private static bool _skippedFirstResume = false;
     public static void MarkConfiguredByBuilder() => _configuredByBuilder = true;
 
@@ -22,6 +23,8 @@ public static class AppAmbitSdk
     {
         try
         {
+            AppKey = appKey;
+            NativePlatforms.SetAppKeyIfNeeded(appKey);
             if (_hasStartedSession) return;
 
             InitializeServices();
@@ -169,6 +172,7 @@ public static class AppAmbitSdk
             ConsumerService.Initialize(storageService, appInfoService, apiService);
             RemoteConfig.Initialize(storageService, appInfoService, apiService);
             BreadcrumbManager.Initialize(apiService!, storageService!);
+            Cms.Initialize(apiService, storageService);
 
             _servicesReady = true;
             Debug.WriteLine("[AppAmbitSdk] Services initialized successfully.");

--- a/sdk/AppAmbit/AppConstants.cs
+++ b/sdk/AppAmbit/AppConstants.cs
@@ -22,4 +22,6 @@ internal class AppConstants
     internal const int TrackEventMaxPropertyLimit = 20;
     internal const int TrackEventPropertyMaxCharacters = 80;
     internal const string LiveSessionStreaming = "live_session_streaming";
+    internal const string CmsBaseUrl = "https://cms.appambit.com/api/v1";
+    internal const string BaseUrlSdk = "https://appambit.com/api";
 }

--- a/sdk/AppAmbit/Cms.cs
+++ b/sdk/AppAmbit/Cms.cs
@@ -17,20 +17,54 @@ public static class Cms
     internal static SemaphoreSlim GetRefreshLock(string contentType)
         => _refreshLocks.GetOrAdd(contentType, _ => new SemaphoreSlim(1, 1));
 
+    internal static void ResetFetchState(string? contentType = null)
+    {
+        if (string.IsNullOrWhiteSpace(contentType))
+        {
+            lock (_fetchedContentTypes)
+            {
+                _fetchedContentTypes.Clear();
+            }
+
+            _refreshLocks.Clear();
+            return;
+        }
+
+        lock (_fetchedContentTypes)
+        {
+            _fetchedContentTypes.Remove(contentType);
+        }
+
+        _refreshLocks.TryRemove(contentType, out _);
+    }
+
     internal static void Initialize(IAPIService? apiService, IStorageService? storageService)
     {
         _apiService = apiService;
         _storageService = storageService;
+        ResetFetchState();
     }
 
     internal static IAPIService? ApiService => _apiService;
     internal static IStorageService? StorageService => _storageService;
 
-    public static Task ClearCache(string contentType)
-        => StorageService?.DeleteCmsEntryAsync(contentType) ?? Task.CompletedTask;
+    public static async Task ClearCache(string contentType)
+    {
+        ResetFetchState(contentType);
+        if (StorageService != null)
+        {
+            await StorageService.DeleteCmsEntryAsync(contentType).ConfigureAwait(false);
+        }
+    }
 
-    public static Task ClearAllCache()
-        => StorageService?.DeleteAllCmsEntriesAsync() ?? Task.CompletedTask;
+    public static async Task ClearAllCache()
+    {
+        ResetFetchState();
+        if (StorageService != null)
+        {
+            await StorageService.DeleteAllCmsEntriesAsync().ConfigureAwait(false);
+        }
+    }
 
     public static ICmsQueryBuilder<T> Content<T>(string contentType) where T : class
     {

--- a/sdk/AppAmbit/Cms.cs
+++ b/sdk/AppAmbit/Cms.cs
@@ -32,7 +32,7 @@ public static class Cms
     public static Task ClearAllCache()
         => StorageService?.DeleteAllCmsEntriesAsync() ?? Task.CompletedTask;
 
-    public static ICmsQueryBuilder<T> For<T>(string contentType) where T : class
+    public static ICmsQueryBuilder<T> Content<T>(string contentType) where T : class
     {
         return new CmsQueryBuilder<T>(contentType);
     }

--- a/sdk/AppAmbit/Cms.cs
+++ b/sdk/AppAmbit/Cms.cs
@@ -11,6 +11,9 @@ public static class Cms
 
     private static readonly HashSet<string> _fetchedContentTypes = new();
     private static readonly ConcurrentDictionary<string, SemaphoreSlim> _refreshLocks = new();
+    private static readonly ConcurrentDictionary<string, object> _queryCache = new();
+
+    internal static ConcurrentDictionary<string, object> QueryCache => _queryCache;
 
     internal static HashSet<string> FetchedContentTypes => _fetchedContentTypes;
 
@@ -27,6 +30,7 @@ public static class Cms
             }
 
             _refreshLocks.Clear();
+            _queryCache.Clear();
             return;
         }
 
@@ -36,6 +40,12 @@ public static class Cms
         }
 
         _refreshLocks.TryRemove(contentType, out _);
+
+        foreach (var key in _queryCache.Keys)
+        {
+            if (key.StartsWith(contentType + "|", StringComparison.Ordinal))
+                _queryCache.TryRemove(key, out _);
+        }
     }
 
     internal static void Initialize(IAPIService? apiService, IStorageService? storageService)

--- a/sdk/AppAmbit/Cms.cs
+++ b/sdk/AppAmbit/Cms.cs
@@ -1,0 +1,39 @@
+using AppAmbit.Services.Interfaces;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace AppAmbit;
+
+public static class Cms
+{
+    private static IAPIService? _apiService;
+    private static IStorageService? _storageService;
+
+    private static readonly HashSet<string> _fetchedContentTypes = new();
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> _refreshLocks = new();
+
+    internal static HashSet<string> FetchedContentTypes => _fetchedContentTypes;
+
+    internal static SemaphoreSlim GetRefreshLock(string contentType)
+        => _refreshLocks.GetOrAdd(contentType, _ => new SemaphoreSlim(1, 1));
+
+    internal static void Initialize(IAPIService? apiService, IStorageService? storageService)
+    {
+        _apiService = apiService;
+        _storageService = storageService;
+    }
+
+    internal static IAPIService? ApiService => _apiService;
+    internal static IStorageService? StorageService => _storageService;
+
+    public static Task Clear(string contentType)
+        => StorageService?.DeleteCmsEntryAsync(contentType) ?? Task.CompletedTask;
+
+    public static Task ClearAll()
+        => StorageService?.DeleteAllCmsEntriesAsync() ?? Task.CompletedTask;
+
+    public static CmsQueryBuilder<T> For<T>(string contentType) where T : class
+    {
+        return new CmsQueryBuilder<T>(contentType);
+    }
+}

--- a/sdk/AppAmbit/Cms.cs
+++ b/sdk/AppAmbit/Cms.cs
@@ -26,13 +26,13 @@ public static class Cms
     internal static IAPIService? ApiService => _apiService;
     internal static IStorageService? StorageService => _storageService;
 
-    public static Task Clear(string contentType)
+    public static Task ClearCache(string contentType)
         => StorageService?.DeleteCmsEntryAsync(contentType) ?? Task.CompletedTask;
 
-    public static Task ClearAll()
+    public static Task ClearAllCache()
         => StorageService?.DeleteAllCmsEntriesAsync() ?? Task.CompletedTask;
 
-    public static CmsQueryBuilder<T> For<T>(string contentType) where T : class
+    public static ICmsQueryBuilder<T> For<T>(string contentType) where T : class
     {
         return new CmsQueryBuilder<T>(contentType);
     }

--- a/sdk/AppAmbit/CmsQueryBuilder.cs
+++ b/sdk/AppAmbit/CmsQueryBuilder.cs
@@ -1,0 +1,297 @@
+using AppAmbit.Models.Cms;
+using AppAmbit.Services.Endpoints;
+using AppAmbit.Services.Interfaces;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Diagnostics;
+using System.Text;
+
+namespace AppAmbit;
+
+public class CmsQueryBuilder<T> where T : class
+{
+    private readonly string _contentType;
+    private static IAPIService? ApiService => Cms.ApiService;
+    private static IStorageService? StorageService => Cms.StorageService;
+
+    private readonly StringBuilder _sqlClause = new();
+    private readonly List<string> _selectionArgs = new();
+    private string? _orderByClause;
+    private int _page = 1;
+    private int _perPage = 20;
+
+    internal CmsQueryBuilder(string contentType)
+    {
+        _contentType = contentType;
+    }
+
+    public CmsQueryBuilder<T> Search(string query)
+    {
+        var trimmed = query?.Trim() ?? "";
+        if (!string.IsNullOrEmpty(trimmed))
+        {
+            if (_sqlClause.Length > 0) _sqlClause.Append(" AND ");
+            _sqlClause.Append("value LIKE ?");
+            _selectionArgs.Add($"%{trimmed}%");
+        }
+        return this;
+    }
+
+    public CmsQueryBuilder<T> Equals(string field, string value) => AddCondition(field, "=", value);
+    public CmsQueryBuilder<T> NotEquals(string field, string value) => AddCondition(field, "!=", value);
+    public CmsQueryBuilder<T> Contains(string field, string value) => AddCondition(field, "LIKE", $"%{value}%");
+    public CmsQueryBuilder<T> StartsWith(string field, string value) => AddCondition(field, "LIKE", $"{value}%");
+
+    public CmsQueryBuilder<T> GreaterThan(string field, object value) => AddNumericCondition(field, ">", value);
+    public CmsQueryBuilder<T> GreaterThanOrEqual(string field, object value) => AddNumericCondition(field, ">=", value);
+    public CmsQueryBuilder<T> LessThan(string field, object value) => AddNumericCondition(field, "<", value);
+    public CmsQueryBuilder<T> LessThanOrEqual(string field, object value) => AddNumericCondition(field, "<=", value);
+
+    public CmsQueryBuilder<T> InList(string field, IEnumerable<string> values)
+    {
+        var list = values.ToList();
+        if (_sqlClause.Length > 0) _sqlClause.Append(" AND ");
+        _sqlClause.Append($"json_extract(value, '$.{field}') IN (");
+        for (int i = 0; i < list.Count; i++)
+        {
+            _sqlClause.Append(i < list.Count - 1 ? "?," : "?");
+            _selectionArgs.Add(list[i]);
+        }
+        _sqlClause.Append(")");
+        return this;
+    }
+
+    public CmsQueryBuilder<T> NotInList(string field, IEnumerable<string> values)
+    {
+        var list = values.ToList();
+        if (_sqlClause.Length > 0) _sqlClause.Append(" AND ");
+        _sqlClause.Append($"json_extract(value, '$.{field}') NOT IN (");
+        for (int i = 0; i < list.Count; i++)
+        {
+            _sqlClause.Append(i < list.Count - 1 ? "?," : "?");
+            _selectionArgs.Add(list[i]);
+        }
+        _sqlClause.Append(")");
+        return this;
+    }
+
+    public CmsQueryBuilder<T> OrderByAscending(string field)
+    {
+        _orderByClause = $"json_extract(value, '$.{field}') ASC";
+        return this;
+    }
+
+    public CmsQueryBuilder<T> OrderByDescending(string field)
+    {
+        _orderByClause = $"json_extract(value, '$.{field}') DESC";
+        return this;
+    }
+
+    public CmsQueryBuilder<T> SetPage(int page) { _page = page; return this; }
+    public CmsQueryBuilder<T> SetPerPage(int perPage) { _perPage = perPage; return this; }
+
+    private CmsQueryBuilder<T> AddCondition(string field, string op, string value)
+    {
+        if (_sqlClause.Length > 0) _sqlClause.Append(" AND ");
+        _sqlClause.Append($"json_extract(value, '$.{field}') {op} ?");
+        _selectionArgs.Add(value);
+        return this;
+    }
+
+    private CmsQueryBuilder<T> AddNumericCondition(string field, string op, object value)
+    {
+        if (_sqlClause.Length > 0) _sqlClause.Append(" AND ");
+        _sqlClause.Append($"CAST(json_extract(value, '$.{field}') AS REAL) {op} ?");
+        _selectionArgs.Add(value?.ToString() ?? "0");
+        return this;
+    }
+
+    public async Task<List<T>> GetListAsync()
+    {
+        if (ApiService == null || StorageService == null)
+            return new List<T>();
+
+        int limit = _perPage;
+        int offset = (_page - 1) * _perPage;
+
+        bool isAlreadyFetched;
+        lock (Cms.FetchedContentTypes)
+        {
+            isAlreadyFetched = Cms.FetchedContentTypes.Contains(_contentType);
+            if (!isAlreadyFetched)
+            {
+                Cms.FetchedContentTypes.Add(_contentType);
+            }
+        }
+
+        if (isAlreadyFetched)
+        {
+            _ = Task.Run(RefreshCacheInBackgroundAsync);
+            return await Task.Run(() => QueryLocalCacheAsync(limit, offset)).ConfigureAwait(false);
+        }
+
+        var cached = await Task.Run(() => QueryLocalCacheAsync(limit, offset)).ConfigureAwait(false);
+
+        if (cached == null || cached.Count == 0)
+        {
+            await FetchRemoteDataSyncAsync().ConfigureAwait(false);
+            return await Task.Run(() => QueryLocalCacheAsync(limit, offset)).ConfigureAwait(false);
+        }
+        else
+        {
+            _ = Task.Run(RefreshCacheInBackgroundAsync);
+            return cached;
+        }
+    }
+
+    private async Task<List<T>> QueryLocalCacheAsync(int limit, int offset)
+    {
+        try
+        {
+            var dataJsonList = await StorageService!.QueryCmsDataAsync(
+                _contentType,
+                _sqlClause.Length > 0 ? _sqlClause.ToString() : null,
+                _selectionArgs.Count > 0 ? _selectionArgs.ToArray() : null,
+                _orderByClause,
+                limit,
+                offset).ConfigureAwait(false);
+
+            var items = new List<T>();
+            foreach (var json in dataJsonList)
+            {
+                var item = JsonConvert.DeserializeObject<T>(json);
+                if (item != null) items.Add(item);
+            }
+            return items;
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"[AppAmbit.Cms] QueryLocalCache failed: {ex.Message}");
+            return new List<T>();
+        }
+    }
+
+    private async Task FetchRemoteDataSyncAsync()
+    {
+        try
+        {
+            var remoteJson = await FetchAllRemoteDataAsync().ConfigureAwait(false);
+            if (remoteJson != null)
+            {
+                var localEntity = await StorageService!.GetCmsEntryAsync(_contentType).ConfigureAwait(false);
+                if (CheckIfDataChanged(localEntity?.JsonData, remoteJson))
+                {
+                    await StorageService!.UpsertCmsEntryAsync(new CmsCacheEntity
+                    {
+                        ContentType = _contentType,
+                        JsonData = remoteJson,
+                        LastSyncedAt = DateTimeOffset.UtcNow.ToUnixTimeSeconds()
+                    }).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"[AppAmbit.Cms] Sync failed: {ex.Message}");
+        }
+    }
+
+    private async Task RefreshCacheInBackgroundAsync()
+    {
+        var sem = Cms.GetRefreshLock(_contentType);
+        if (!await sem.WaitAsync(0).ConfigureAwait(false)) return;
+
+        try
+        {
+            var remoteJson = await FetchAllRemoteDataAsync().ConfigureAwait(false);
+            if (remoteJson != null)
+            {
+                var localEntity = await StorageService!.GetCmsEntryAsync(_contentType).ConfigureAwait(false);
+                if (CheckIfDataChanged(localEntity?.JsonData, remoteJson))
+                {
+                    await StorageService!.UpsertCmsEntryAsync(new CmsCacheEntity
+                    {
+                        ContentType = _contentType,
+                        JsonData = remoteJson,
+                        LastSyncedAt = DateTimeOffset.UtcNow.ToUnixTimeSeconds()
+                    }).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"[AppAmbit.Cms] Background refresh failed: {ex.Message}");
+        }
+        finally
+        {
+            sem.Release();
+        }
+    }
+
+    private bool CheckIfDataChanged(string? localJson, string remoteJson)
+    {
+        if (localJson == null) return true;
+        if (localJson.Length != remoteJson.Length) return true;
+        return !string.Equals(localJson, remoteJson, StringComparison.Ordinal);
+    }
+
+    private async Task<string?> FetchAllRemoteDataAsync()
+    {
+        try
+        {
+            int page = 1;
+            const int perPage = 20;
+
+            var firstEndpoint = new CmsEndpoint(_contentType, page, perPage);
+            var firstResult = await ApiService!.ExecuteRequest<JObject>(firstEndpoint).ConfigureAwait(false);
+
+            if (firstResult == null) return null;
+
+            // PAGE 1 INVALIDATION RULES
+            bool isNotFound = firstResult.ErrorType == Enums.ApiErrorType.NotFound;
+            bool isEmpty = firstResult.Data != null 
+                           && firstResult.Data["data"] is JArray arr 
+                           && arr.Count == 0 
+                           && firstResult.Data["meta"]?["total"]?.Value<int>() == 0;
+
+            if (isNotFound || isEmpty)
+            {
+                await StorageService!.DeleteCmsEntryAsync(_contentType).ConfigureAwait(false);
+                return null;
+            }
+
+            if (firstResult.Data == null) return null;
+
+            var firstJson = firstResult.Data;
+            if (!firstJson.ContainsKey("data")) return firstJson.ToString();
+
+            var allData = firstJson["data"] as JArray ?? new JArray();
+
+            if (firstJson.ContainsKey("meta"))
+            {
+                var meta = firstJson["meta"]!;
+                int total = meta["total"]?.Value<int>() ?? 0;
+                int totalPages = (int)Math.Ceiling((double)total / perPage);
+
+                for (int p = 2; p <= totalPages; p++)
+                {
+                    var nextEndpoint = new CmsEndpoint(_contentType, p, perPage);
+                    var nextResult = await ApiService!.ExecuteRequest<JObject>(nextEndpoint).ConfigureAwait(false);
+                    if (nextResult?.Data?["data"] is JArray nextData)
+                    {
+                        foreach (var item in nextData)
+                            allData.Add(item);
+                    }
+                }
+            }
+
+            firstJson["data"] = allData;
+            return firstJson.ToString(Formatting.None);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"[AppAmbit.Cms] FetchAllRemoteData failed: {ex.Message}");
+            return null;
+        }
+    }
+}

--- a/sdk/AppAmbit/CmsQueryBuilder.cs
+++ b/sdk/AppAmbit/CmsQueryBuilder.cs
@@ -1,4 +1,5 @@
 using AppAmbit.Models.Cms;
+using AppAmbit.Services;
 using AppAmbit.Services.Endpoints;
 using AppAmbit.Services.Interfaces;
 using Newtonsoft.Json;
@@ -11,8 +12,8 @@ namespace AppAmbit;
 public class CmsQueryBuilder<T> : ICmsQueryBuilder<T> where T : class
 {
     private readonly string _contentType;
-    private static IAPIService? ApiService => Cms.ApiService;
-    private static IStorageService? StorageService => Cms.StorageService;
+    private static IAPIService? _apiService => Cms.ApiService;
+    private static IStorageService? _storageService => Cms.StorageService;
 
     private readonly StringBuilder _sqlClause = new();
     private readonly List<string> _selectionArgs = new();
@@ -21,140 +22,156 @@ public class CmsQueryBuilder<T> : ICmsQueryBuilder<T> where T : class
     private int _page = 1;
     private int _perPage = 20;
 
+    private int PaginationLimit  => _isPaginated ? _perPage : 0;
+    private int PaginationOffset => _isPaginated ? (_page - 1) * _perPage : 0;
+
+    private static readonly JsonSerializerSettings _deserializeSettings = new()
+    {
+        Error = (_, args) => args.ErrorContext.Handled = true,
+        NullValueHandling = NullValueHandling.Ignore
+    };
+
     internal CmsQueryBuilder(string contentType)
     {
         _contentType = contentType;
     }
 
+
     public ICmsQueryBuilder<T> Search(string query)
     {
         var trimmed = query?.Trim() ?? "";
         if (!string.IsNullOrEmpty(trimmed))
-        {
-            if (_sqlClause.Length > 0) _sqlClause.Append(" AND ");
-            _sqlClause.Append("value LIKE ?");
-            _selectionArgs.Add($"%{trimmed}%");
-        }
+            AppendClause("e.value LIKE ?", $"%{trimmed}%");
         return this;
     }
 
-    public ICmsQueryBuilder<T> Equals(string field, string value) => AddCondition(field, "=", value);
-    public ICmsQueryBuilder<T> NotEquals(string field, string value) => AddCondition(field, "!=", value);
-    public ICmsQueryBuilder<T> Contains(string field, string value) => AddCondition(field, "LIKE", $"%{value}%");
-    public ICmsQueryBuilder<T> StartsWith(string field, string value) => AddCondition(field, "LIKE", $"{value}%");
+    public ICmsQueryBuilder<T> Equals(string field, string value)          => AddCondition(field, "=",    value);
+    public ICmsQueryBuilder<T> NotEquals(string field, string value)       => AddCondition(field, "!=",   value);
+    public ICmsQueryBuilder<T> Contains(string field, string value)        => AddCondition(field, "LIKE", $"%{value}%");
+    public ICmsQueryBuilder<T> StartsWith(string field, string value)      => AddCondition(field, "LIKE", $"{value}%");
 
-    public ICmsQueryBuilder<T> GreaterThan(string field, object value) => AddNumericCondition(field, ">", value);
+    public ICmsQueryBuilder<T> GreaterThan(string field, object value)        => AddNumericCondition(field, ">",  value);
     public ICmsQueryBuilder<T> GreaterThanOrEqual(string field, object value) => AddNumericCondition(field, ">=", value);
-    public ICmsQueryBuilder<T> LessThan(string field, object value) => AddNumericCondition(field, "<", value);
-    public ICmsQueryBuilder<T> LessThanOrEqual(string field, object value) => AddNumericCondition(field, "<=", value);
+    public ICmsQueryBuilder<T> LessThan(string field, object value)           => AddNumericCondition(field, "<",  value);
+    public ICmsQueryBuilder<T> LessThanOrEqual(string field, object value)    => AddNumericCondition(field, "<=", value);
 
-    public ICmsQueryBuilder<T> InList(string field, IEnumerable<string> values)
-    {
-        var list = values.ToList();
-        if (_sqlClause.Length > 0) _sqlClause.Append(" AND ");
-        _sqlClause.Append($"json_extract(value, '$.{field}') IN (");
-        for (int i = 0; i < list.Count; i++)
-        {
-            _sqlClause.Append(i < list.Count - 1 ? "?," : "?");
-            _selectionArgs.Add(list[i]);
-        }
-        _sqlClause.Append(")");
-        return this;
-    }
+    public ICmsQueryBuilder<T> InList(string field, IEnumerable<string> values)    => AddListCondition(field, exists: true,  values);
+    public ICmsQueryBuilder<T> NotInList(string field, IEnumerable<string> values) => AddListCondition(field, exists: false, values);
 
-    public ICmsQueryBuilder<T> NotInList(string field, IEnumerable<string> values)
-    {
-        var list = values.ToList();
-        if (_sqlClause.Length > 0) _sqlClause.Append(" AND ");
-        _sqlClause.Append($"json_extract(value, '$.{field}') NOT IN (");
-        for (int i = 0; i < list.Count; i++)
-        {
-            _sqlClause.Append(i < list.Count - 1 ? "?," : "?");
-            _selectionArgs.Add(list[i]);
-        }
-        _sqlClause.Append(")");
-        return this;
-    }
+    public ICmsQueryBuilder<T> OrderByAscending(string field)  => SetOrderBy(field, "ASC");
+    public ICmsQueryBuilder<T> OrderByDescending(string field) => SetOrderBy(field, "DESC");
 
-    public ICmsQueryBuilder<T> OrderByAscending(string field)
-    {
-        _orderByClause = $"json_extract(value, '$.{field}') ASC";
-        return this;
-    }
-
-    public ICmsQueryBuilder<T> OrderByDescending(string field)
-    {
-        _orderByClause = $"json_extract(value, '$.{field}') DESC";
-        return this;
-    }
-
-    public ICmsQueryBuilder<T> GetPage(int page) { _isPaginated = true; _page = page; return this; }
+    public ICmsQueryBuilder<T> GetPage(int page)       { _isPaginated = true; _page    = page;    return this; }
     public ICmsQueryBuilder<T> GetPerPage(int perPage) { _isPaginated = true; _perPage = perPage; return this; }
+
+
+    public async Task<List<T>> GetListAsync()
+    {
+        if (_apiService == null || _storageService == null)
+            return [];
+
+        if (_isPaginated && (_page < 1 || _perPage < 1))
+            return [];
+
+        var cacheKey = BuildCacheKey();
+        if (Cms.QueryCache.TryGetValue(cacheKey, out var cachedResult))
+        {
+            Debug.WriteLine($"[AppAmbit.Cms] Query cache hit: {cacheKey}");
+            return (List<T>)cachedResult;
+        }
+
+        bool alreadyFetched;
+        lock (Cms.FetchedContentTypes)
+        {
+            alreadyFetched = Cms.FetchedContentTypes.Contains(_contentType);
+            if (!alreadyFetched) Cms.FetchedContentTypes.Add(_contentType);
+        }
+
+        List<T> result;
+
+        if (alreadyFetched)
+        {
+            result = await QueryLocalAsync().ConfigureAwait(false);
+        }
+        else
+        {
+            var cached = await QueryLocalAsync().ConfigureAwait(false);
+
+            if (cached == null || cached.Count == 0)
+            {
+                await SyncRemoteAsync().ConfigureAwait(false);
+                result = await QueryLocalAsync().ConfigureAwait(false);
+            }
+            else
+            {
+                _ = Task.Run(RefreshCacheInBackgroundAsync);
+                result = cached;
+            }
+        }
+
+        Cms.QueryCache.TryAdd(cacheKey, result);
+        Debug.WriteLine($"[AppAmbit.Cms] Query cached: {cacheKey} ({result.Count} items)");
+
+        return result;
+    }
+
+    private string BuildCacheKey()
+    {
+        return $"{_contentType}|{_sqlClause}|{string.Join(",", _selectionArgs)}|{_orderByClause ?? ""}|{PaginationLimit},{PaginationOffset}";
+    }
+
+    private void AppendClause(string fragment, string arg)
+    {
+        if (_sqlClause.Length > 0) _sqlClause.Append(" AND ");
+        _sqlClause.Append(fragment);
+        _selectionArgs.Add(arg);
+    }
+
+    private static string NormalizeBool(string value) =>
+        value.Equals("true",  StringComparison.OrdinalIgnoreCase) ? "1" :
+        value.Equals("false", StringComparison.OrdinalIgnoreCase) ? "0" : value;
 
     private ICmsQueryBuilder<T> AddCondition(string field, string op, string value)
     {
         if (_sqlClause.Length > 0) _sqlClause.Append(" AND ");
-        _sqlClause.Append($"json_extract(value, '$.{field}') {op} ?");
-        _selectionArgs.Add(value);
+        _sqlClause.Append($"CAST(json_extract(e.value, '$.{field}') AS TEXT) {op} ?");
+        _selectionArgs.Add(NormalizeBool(value));
         return this;
     }
 
     private ICmsQueryBuilder<T> AddNumericCondition(string field, string op, object value)
     {
         if (_sqlClause.Length > 0) _sqlClause.Append(" AND ");
-        _sqlClause.Append($"CAST(json_extract(value, '$.{field}') AS REAL) {op} ?");
+        _sqlClause.Append($"CAST(json_extract(e.value, '$.{field}') AS REAL) {op} ?");
         _selectionArgs.Add(value?.ToString() ?? "0");
         return this;
     }
 
-    public async Task<List<T>> GetListAsync()
+    private ICmsQueryBuilder<T> AddListCondition(string field, bool exists, IEnumerable<string> values)
     {
-        if (ApiService == null || StorageService == null)
-            return new List<T>();
-
-        int limit = _isPaginated ? _perPage : 0;
-        int offset = _isPaginated ? (_page - 1) * _perPage : 0;
-
-        bool alreadyFetched;
-        lock (Cms.FetchedContentTypes)
-        {
-            alreadyFetched = Cms.FetchedContentTypes.Contains(_contentType);
-            if (!alreadyFetched)
-            {
-                Cms.FetchedContentTypes.Add(_contentType);
-            }
-        }
-
-        if (alreadyFetched)
-        {
-            return await QueryLocalCacheAsync(limit, offset).ConfigureAwait(false);
-        }
-
-        var cached = await QueryLocalCacheAsync(limit, offset).ConfigureAwait(false);
-
-        if (cached == null || cached.Count == 0)
-        {
-            await FetchRemoteDataSyncAsync().ConfigureAwait(false);
-            return await QueryLocalCacheAsync(limit, offset).ConfigureAwait(false);
-        }
-
-        _ = Task.Run(RefreshCacheInBackgroundAsync);
-        return cached;
+        var list = values.Select(NormalizeBool).ToList();
+        if (_sqlClause.Length > 0) _sqlClause.Append(" AND ");
+        _sqlClause.Append(StorageService.BuildListClause(field, exists, list.Count));
+        _selectionArgs.AddRange(list);
+        return this;
     }
 
-    private static readonly JsonSerializerSettings _deserializeSettings = new()
+    private ICmsQueryBuilder<T> SetOrderBy(string field, string direction)
     {
-        // Swallow per-field type mismatches (e.g. array where string expected) so one
-        // bad field never discards the whole item.
-        Error = (_, args) => args.ErrorContext.Handled = true,
-        NullValueHandling = NullValueHandling.Ignore
-    };
+        _orderByClause =
+            $"CAST(json_extract(e.value, '$.{field}') AS REAL) {direction}, " +
+            $"CAST(json_extract(e.value, '$.{field}') AS TEXT) COLLATE NOCASE {direction}";
+        return this;
+    }
 
-    private async Task<List<T>> QueryLocalCacheAsync(int limit, int offset)
+    private Task<List<T>> QueryLocalAsync() =>
+        QueryLocalAsync(PaginationLimit, PaginationOffset);
+
+    private async Task<List<T>> QueryLocalAsync(int limit, int offset)
     {
         try
         {
-            var dataJsonList = await StorageService!.QueryCmsDataAsync(
+            var dataJsonList = await _storageService!.QueryCmsDataAsync(
                 _contentType,
                 _sqlClause.Length > 0 ? _sqlClause.ToString() : null,
                 _selectionArgs.Count > 0 ? _selectionArgs.ToArray() : null,
@@ -180,28 +197,17 @@ public class CmsQueryBuilder<T> : ICmsQueryBuilder<T> where T : class
         catch (Exception ex)
         {
             Debug.WriteLine($"[AppAmbit.Cms] QueryLocalCache failed: {ex.Message}");
-            return new List<T>();
+            return [];
         }
     }
 
-    private async Task FetchRemoteDataSyncAsync()
+    private async Task SyncRemoteAsync()
     {
         try
         {
             var remoteJson = await FetchAllRemoteDataAsync().ConfigureAwait(false);
             if (remoteJson != null)
-            {
-                var localEntity = await StorageService!.GetCmsEntryAsync(_contentType).ConfigureAwait(false);
-                if (CheckIfDataChanged(localEntity?.JsonData, remoteJson))
-                {
-                    await StorageService!.UpsertCmsEntryAsync(new CmsCacheEntity
-                    {
-                        ContentType = _contentType,
-                        JsonData = remoteJson,
-                        LastSyncedAt = DateTimeOffset.UtcNow.ToUnixTimeSeconds()
-                    }).ConfigureAwait(false);
-                }
-            }
+                await _storageService!.UpsertCmsEntryIfChangedAsync(_contentType, remoteJson).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -218,18 +224,7 @@ public class CmsQueryBuilder<T> : ICmsQueryBuilder<T> where T : class
         {
             var remoteJson = await FetchAllRemoteDataAsync().ConfigureAwait(false);
             if (remoteJson != null)
-            {
-                var localEntity = await StorageService!.GetCmsEntryAsync(_contentType).ConfigureAwait(false);
-                if (CheckIfDataChanged(localEntity?.JsonData, remoteJson))
-                {
-                    await StorageService!.UpsertCmsEntryAsync(new CmsCacheEntity
-                    {
-                        ContentType = _contentType,
-                        JsonData = remoteJson,
-                        LastSyncedAt = DateTimeOffset.UtcNow.ToUnixTimeSeconds()
-                    }).ConfigureAwait(false);
-                }
-            }
+                await _storageService!.UpsertCmsEntryIfChangedAsync(_contentType, remoteJson).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -241,45 +236,37 @@ public class CmsQueryBuilder<T> : ICmsQueryBuilder<T> where T : class
         }
     }
 
-    private bool CheckIfDataChanged(string? localJson, string remoteJson)
-    {
-        if (localJson == null) return true;
-        if (localJson.Length != remoteJson.Length) return true;
-        return !string.Equals(localJson, remoteJson, StringComparison.Ordinal);
-    }
 
     private async Task<string?> FetchAllRemoteDataAsync()
     {
         try
         {
-            int page = 1;
-            const int perPage = 20;
+            const int fetchPageSize = 20;
 
-            var firstEndpoint = new CmsEndpoint(_contentType, page, perPage);
-            var firstResult = await ApiService!.ExecuteRequest<JObject>(firstEndpoint).ConfigureAwait(false);
+            var firstResult = await _apiService!
+                .ExecuteRequest<JObject>(new CmsEndpoint(_contentType, 1, fetchPageSize))
+                .ConfigureAwait(false);
 
-            if (firstResult == null || firstResult.Data == null) return null;
+            if (firstResult?.Data == null) return null;
 
             var firstJson = firstResult.Data;
             if (!firstJson.ContainsKey("data")) return firstJson.ToString();
 
-            var allData = firstJson["data"] as JArray ?? new JArray();
+            var allData = firstJson["data"] as JArray ?? [];
 
-            if (firstJson.ContainsKey("meta"))
+            if (firstJson.TryGetValue("meta", out var meta))
             {
-                var meta = firstJson["meta"]!;
-                int total = meta["total"]?.Value<int>() ?? 0;
-                int totalPages = (int)Math.Ceiling((double)total / perPage);
+                int total      = meta["total"]?.Value<int>() ?? 0;
+                int totalPages = (int)Math.Ceiling((double)total / fetchPageSize);
 
                 for (int p = 2; p <= totalPages; p++)
                 {
-                    var nextEndpoint = new CmsEndpoint(_contentType, p, perPage);
-                    var nextResult = await ApiService!.ExecuteRequest<JObject>(nextEndpoint).ConfigureAwait(false);
-                    if (nextResult?.Data?["data"] is JArray nextData)
-                    {
-                        foreach (var item in nextData)
-                            allData.Add(item);
-                    }
+                    var next = await _apiService!
+                        .ExecuteRequest<JObject>(new CmsEndpoint(_contentType, p, fetchPageSize))
+                        .ConfigureAwait(false);
+
+                    if (next?.Data?["data"] is JArray nextData)
+                        foreach (var item in nextData) allData.Add(item);
                 }
             }
 

--- a/sdk/AppAmbit/CmsQueryBuilder.cs
+++ b/sdk/AppAmbit/CmsQueryBuilder.cs
@@ -115,35 +115,40 @@ public class CmsQueryBuilder<T> : ICmsQueryBuilder<T> where T : class
         int limit = _isPaginated ? _perPage : 0;
         int offset = _isPaginated ? (_page - 1) * _perPage : 0;
 
-        bool isAlreadyFetched;
+        bool alreadyFetched;
         lock (Cms.FetchedContentTypes)
         {
-            isAlreadyFetched = Cms.FetchedContentTypes.Contains(_contentType);
-            if (!isAlreadyFetched)
+            alreadyFetched = Cms.FetchedContentTypes.Contains(_contentType);
+            if (!alreadyFetched)
             {
                 Cms.FetchedContentTypes.Add(_contentType);
             }
         }
 
-        if (isAlreadyFetched)
+        if (alreadyFetched)
         {
-            _ = Task.Run(RefreshCacheInBackgroundAsync);
-            return await Task.Run(() => QueryLocalCacheAsync(limit, offset)).ConfigureAwait(false);
+            return await QueryLocalCacheAsync(limit, offset).ConfigureAwait(false);
         }
 
-        var cached = await Task.Run(() => QueryLocalCacheAsync(limit, offset)).ConfigureAwait(false);
+        var cached = await QueryLocalCacheAsync(limit, offset).ConfigureAwait(false);
 
         if (cached == null || cached.Count == 0)
         {
             await FetchRemoteDataSyncAsync().ConfigureAwait(false);
-            return await Task.Run(() => QueryLocalCacheAsync(limit, offset)).ConfigureAwait(false);
+            return await QueryLocalCacheAsync(limit, offset).ConfigureAwait(false);
         }
-        else
-        {
-            _ = Task.Run(RefreshCacheInBackgroundAsync);
-            return cached;
-        }
+
+        _ = Task.Run(RefreshCacheInBackgroundAsync);
+        return cached;
     }
+
+    private static readonly JsonSerializerSettings _deserializeSettings = new()
+    {
+        // Swallow per-field type mismatches (e.g. array where string expected) so one
+        // bad field never discards the whole item.
+        Error = (_, args) => args.ErrorContext.Handled = true,
+        NullValueHandling = NullValueHandling.Ignore
+    };
 
     private async Task<List<T>> QueryLocalCacheAsync(int limit, int offset)
     {
@@ -160,8 +165,15 @@ public class CmsQueryBuilder<T> : ICmsQueryBuilder<T> where T : class
             var items = new List<T>();
             foreach (var json in dataJsonList)
             {
-                var item = JsonConvert.DeserializeObject<T>(json);
-                if (item != null) items.Add(item);
+                try
+                {
+                    var item = JsonConvert.DeserializeObject<T>(json, _deserializeSettings);
+                    if (item != null) items.Add(item);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"[AppAmbit.Cms] Skipped item — deserialization failed: {ex.Message}");
+                }
             }
             return items;
         }
@@ -246,20 +258,7 @@ public class CmsQueryBuilder<T> : ICmsQueryBuilder<T> where T : class
             var firstEndpoint = new CmsEndpoint(_contentType, page, perPage);
             var firstResult = await ApiService!.ExecuteRequest<JObject>(firstEndpoint).ConfigureAwait(false);
 
-            if (firstResult == null) return null;
-
-            bool isNotFound = firstResult.ErrorType == Enums.ApiErrorType.NotFound;
-            bool isEmpty = firstResult.Data != null 
-                           && firstResult.Data["data"] is JArray arr 
-                           && arr.Count == 0 
-                           && firstResult.Data["meta"]?["total"]?.Value<int>() == 0;
-
-            if (isNotFound || isEmpty)
-            {
-                return null;
-            }
-
-            if (firstResult.Data == null) return null;
+            if (firstResult == null || firstResult.Data == null) return null;
 
             var firstJson = firstResult.Data;
             if (!firstJson.ContainsKey("data")) return firstJson.ToString();

--- a/sdk/AppAmbit/CmsQueryBuilder.cs
+++ b/sdk/AppAmbit/CmsQueryBuilder.cs
@@ -8,7 +8,7 @@ using System.Text;
 
 namespace AppAmbit;
 
-public class CmsQueryBuilder<T> where T : class
+public class CmsQueryBuilder<T> : ICmsQueryBuilder<T> where T : class
 {
     private readonly string _contentType;
     private static IAPIService? ApiService => Cms.ApiService;
@@ -25,7 +25,7 @@ public class CmsQueryBuilder<T> where T : class
         _contentType = contentType;
     }
 
-    public CmsQueryBuilder<T> Search(string query)
+    public ICmsQueryBuilder<T> Search(string query)
     {
         var trimmed = query?.Trim() ?? "";
         if (!string.IsNullOrEmpty(trimmed))
@@ -37,17 +37,17 @@ public class CmsQueryBuilder<T> where T : class
         return this;
     }
 
-    public CmsQueryBuilder<T> Equals(string field, string value) => AddCondition(field, "=", value);
-    public CmsQueryBuilder<T> NotEquals(string field, string value) => AddCondition(field, "!=", value);
-    public CmsQueryBuilder<T> Contains(string field, string value) => AddCondition(field, "LIKE", $"%{value}%");
-    public CmsQueryBuilder<T> StartsWith(string field, string value) => AddCondition(field, "LIKE", $"{value}%");
+    public ICmsQueryBuilder<T> Equals(string field, string value) => AddCondition(field, "=", value);
+    public ICmsQueryBuilder<T> NotEquals(string field, string value) => AddCondition(field, "!=", value);
+    public ICmsQueryBuilder<T> Contains(string field, string value) => AddCondition(field, "LIKE", $"%{value}%");
+    public ICmsQueryBuilder<T> StartsWith(string field, string value) => AddCondition(field, "LIKE", $"{value}%");
 
-    public CmsQueryBuilder<T> GreaterThan(string field, object value) => AddNumericCondition(field, ">", value);
-    public CmsQueryBuilder<T> GreaterThanOrEqual(string field, object value) => AddNumericCondition(field, ">=", value);
-    public CmsQueryBuilder<T> LessThan(string field, object value) => AddNumericCondition(field, "<", value);
-    public CmsQueryBuilder<T> LessThanOrEqual(string field, object value) => AddNumericCondition(field, "<=", value);
+    public ICmsQueryBuilder<T> GreaterThan(string field, object value) => AddNumericCondition(field, ">", value);
+    public ICmsQueryBuilder<T> GreaterThanOrEqual(string field, object value) => AddNumericCondition(field, ">=", value);
+    public ICmsQueryBuilder<T> LessThan(string field, object value) => AddNumericCondition(field, "<", value);
+    public ICmsQueryBuilder<T> LessThanOrEqual(string field, object value) => AddNumericCondition(field, "<=", value);
 
-    public CmsQueryBuilder<T> InList(string field, IEnumerable<string> values)
+    public ICmsQueryBuilder<T> InList(string field, IEnumerable<string> values)
     {
         var list = values.ToList();
         if (_sqlClause.Length > 0) _sqlClause.Append(" AND ");
@@ -61,7 +61,7 @@ public class CmsQueryBuilder<T> where T : class
         return this;
     }
 
-    public CmsQueryBuilder<T> NotInList(string field, IEnumerable<string> values)
+    public ICmsQueryBuilder<T> NotInList(string field, IEnumerable<string> values)
     {
         var list = values.ToList();
         if (_sqlClause.Length > 0) _sqlClause.Append(" AND ");
@@ -75,22 +75,22 @@ public class CmsQueryBuilder<T> where T : class
         return this;
     }
 
-    public CmsQueryBuilder<T> OrderByAscending(string field)
+    public ICmsQueryBuilder<T> OrderByAscending(string field)
     {
         _orderByClause = $"json_extract(value, '$.{field}') ASC";
         return this;
     }
 
-    public CmsQueryBuilder<T> OrderByDescending(string field)
+    public ICmsQueryBuilder<T> OrderByDescending(string field)
     {
         _orderByClause = $"json_extract(value, '$.{field}') DESC";
         return this;
     }
 
-    public CmsQueryBuilder<T> SetPage(int page) { _page = page; return this; }
-    public CmsQueryBuilder<T> SetPerPage(int perPage) { _perPage = perPage; return this; }
+    public ICmsQueryBuilder<T> GetPage(int page) { _page = page; return this; }
+    public ICmsQueryBuilder<T> GetPerPage(int perPage) { _perPage = perPage; return this; }
 
-    private CmsQueryBuilder<T> AddCondition(string field, string op, string value)
+    private ICmsQueryBuilder<T> AddCondition(string field, string op, string value)
     {
         if (_sqlClause.Length > 0) _sqlClause.Append(" AND ");
         _sqlClause.Append($"json_extract(value, '$.{field}') {op} ?");
@@ -98,7 +98,7 @@ public class CmsQueryBuilder<T> where T : class
         return this;
     }
 
-    private CmsQueryBuilder<T> AddNumericCondition(string field, string op, object value)
+    private ICmsQueryBuilder<T> AddNumericCondition(string field, string op, object value)
     {
         if (_sqlClause.Length > 0) _sqlClause.Append(" AND ");
         _sqlClause.Append($"CAST(json_extract(value, '$.{field}') AS REAL) {op} ?");

--- a/sdk/AppAmbit/CmsQueryBuilder.cs
+++ b/sdk/AppAmbit/CmsQueryBuilder.cs
@@ -17,6 +17,7 @@ public class CmsQueryBuilder<T> : ICmsQueryBuilder<T> where T : class
     private readonly StringBuilder _sqlClause = new();
     private readonly List<string> _selectionArgs = new();
     private string? _orderByClause;
+    private bool _isPaginated;
     private int _page = 1;
     private int _perPage = 20;
 
@@ -87,8 +88,8 @@ public class CmsQueryBuilder<T> : ICmsQueryBuilder<T> where T : class
         return this;
     }
 
-    public ICmsQueryBuilder<T> GetPage(int page) { _page = page; return this; }
-    public ICmsQueryBuilder<T> GetPerPage(int perPage) { _perPage = perPage; return this; }
+    public ICmsQueryBuilder<T> GetPage(int page) { _isPaginated = true; _page = page; return this; }
+    public ICmsQueryBuilder<T> GetPerPage(int perPage) { _isPaginated = true; _perPage = perPage; return this; }
 
     private ICmsQueryBuilder<T> AddCondition(string field, string op, string value)
     {
@@ -111,8 +112,8 @@ public class CmsQueryBuilder<T> : ICmsQueryBuilder<T> where T : class
         if (ApiService == null || StorageService == null)
             return new List<T>();
 
-        int limit = _perPage;
-        int offset = (_page - 1) * _perPage;
+        int limit = _isPaginated ? _perPage : 0;
+        int offset = _isPaginated ? (_page - 1) * _perPage : 0;
 
         bool isAlreadyFetched;
         lock (Cms.FetchedContentTypes)
@@ -247,7 +248,6 @@ public class CmsQueryBuilder<T> : ICmsQueryBuilder<T> where T : class
 
             if (firstResult == null) return null;
 
-            // PAGE 1 INVALIDATION RULES
             bool isNotFound = firstResult.ErrorType == Enums.ApiErrorType.NotFound;
             bool isEmpty = firstResult.Data != null 
                            && firstResult.Data["data"] is JArray arr 

--- a/sdk/AppAmbit/CmsQueryBuilder.cs
+++ b/sdk/AppAmbit/CmsQueryBuilder.cs
@@ -256,7 +256,6 @@ public class CmsQueryBuilder<T> : ICmsQueryBuilder<T> where T : class
 
             if (isNotFound || isEmpty)
             {
-                await StorageService!.DeleteCmsEntryAsync(_contentType).ConfigureAwait(false);
                 return null;
             }
 

--- a/sdk/AppAmbit/CmsQueryBuilder.cs
+++ b/sdk/AppAmbit/CmsQueryBuilder.cs
@@ -254,20 +254,16 @@ public class CmsQueryBuilder<T> : ICmsQueryBuilder<T> where T : class
 
             var allData = firstJson["data"] as JArray ?? [];
 
-            if (firstJson.TryGetValue("meta", out var meta))
+            var lastPage = firstJson.SelectToken("meta.last_page")?.Value<int>() ?? 1;
+
+            for (int p = 2; p <= lastPage; p++)
             {
-                int total      = meta["total"]?.Value<int>() ?? 0;
-                int totalPages = (int)Math.Ceiling((double)total / fetchPageSize);
+                var next = await _apiService!
+                    .ExecuteRequest<JObject>(new CmsEndpoint(_contentType, p, fetchPageSize))
+                    .ConfigureAwait(false);
 
-                for (int p = 2; p <= totalPages; p++)
-                {
-                    var next = await _apiService!
-                        .ExecuteRequest<JObject>(new CmsEndpoint(_contentType, p, fetchPageSize))
-                        .ConfigureAwait(false);
-
-                    if (next?.Data?["data"] is JArray nextData)
-                        foreach (var item in nextData) allData.Add(item);
-                }
+                if (next?.Data?["data"] is JArray nextData)
+                    foreach (var item in nextData) allData.Add(item);
             }
 
             firstJson["data"] = allData;

--- a/sdk/AppAmbit/Enums/ApiErrorType.cs
+++ b/sdk/AppAmbit/Enums/ApiErrorType.cs
@@ -4,5 +4,6 @@ public enum ApiErrorType
     None,
     Unauthorized,
     NetworkUnavailable,
+    NotFound,
     Unknown
 }

--- a/sdk/AppAmbit/Models/Cms/CmsCacheEntity.cs
+++ b/sdk/AppAmbit/Models/Cms/CmsCacheEntity.cs
@@ -1,0 +1,12 @@
+using SQLite;
+
+namespace AppAmbit.Models.Cms;
+
+[Table("CmsEntries")]
+public class CmsCacheEntity
+{
+    [PrimaryKey]
+    public string ContentType { get; set; } = string.Empty;
+    public string? JsonData { get; set; }
+    public long LastSyncedAt { get; set; }
+}

--- a/sdk/AppAmbit/Models/Cms/CmsResponse.cs
+++ b/sdk/AppAmbit/Models/Cms/CmsResponse.cs
@@ -1,0 +1,27 @@
+using Newtonsoft.Json;
+
+namespace AppAmbit.Models.Cms;
+
+public class CmsResponse<T>
+{
+    [JsonProperty("data")]
+    public T? Data { get; set; }
+
+    [JsonProperty("meta")]
+    public CmsMeta? Meta { get; set; }
+}
+
+public class CmsMeta
+{
+    [JsonProperty("total")]
+    public int Total { get; set; }
+
+    [JsonProperty("per_page")]
+    public int PerPage { get; set; }
+
+    [JsonProperty("current_page")]
+    public int CurrentPage { get; set; }
+
+    [JsonProperty("last_page")]
+    public int LastPage { get; set; }
+}

--- a/sdk/AppAmbit/NativePlatforms.cs
+++ b/sdk/AppAmbit/NativePlatforms.cs
@@ -23,6 +23,13 @@ internal static partial class NativePlatforms
         AppAmbitSdk.InternalStart(_appKey ?? string.Empty);
     }
 
+    internal static string? GetAppKey() => _appKey;
+
+    internal static void SetAppKeyIfNeeded(string appKey)
+    {
+        _appKey ??= appKey;
+    }
+
     public static void EnableNativePageBreadcrumbs()
     {
         PlatformEnablePageBreadcrumbs();

--- a/sdk/AppAmbit/Services/APIService.cs
+++ b/sdk/AppAmbit/Services/APIService.cs
@@ -169,10 +169,10 @@ public class APIService : IAPIService
             .Accept
             .Add(new MediaTypeWithQualityHeaderValue("application/json"));
             
-        // httpClient.DefaultRequestHeaders.CacheControl = new CacheControlHeaderValue 
-        // { 
-        //     NoCache = true 
-        // };
+        httpClient.DefaultRequestHeaders.CacheControl = new CacheControlHeaderValue 
+        { 
+            NoCache = true 
+        };
 
         var responseMessage = await HttpResponseMessage(endpoint, httpClient);
         return responseMessage;
@@ -263,7 +263,6 @@ public class APIService : IAPIService
         HttpContent content;
         if (payload is Log log)
         {
-            PrintLogWithoutFile(log);
             var multipartFormDataContent = SerializeToMultipartFormDataContent(log);
             content = multipartFormDataContent;
 
@@ -280,13 +279,6 @@ public class APIService : IAPIService
         return content;
     }
 
-    [Conditional("DEBUG")]
-    private static void PrintLogWithoutFile(Log log)
-    {
-        var data = JsonConvert.SerializeObject(log);
-        Debug.WriteLine($"data:{data}");
-    }
-
     private static HttpContent SerializeToJSONStringContent(object payload)
     {
         var settings = new JsonSerializerSettings
@@ -295,14 +287,12 @@ public class APIService : IAPIService
         };
 
         var json = JsonConvert.SerializeObject(payload, settings);
-        Debug.WriteLine($"data:{json}");
 
         return new StringContent(json, Encoding.UTF8, "application/json");
     }
 
     private MultipartFormDataContent SerializeToMultipartFormDataContent(object payload)
     {
-        Debug.WriteLine("SerializeToMultipartFormDataContent");
         var formData = new MultipartFormDataContent();
         formData.AddObjectToMultipartFormDataContent(payload);
         return formData;

--- a/sdk/AppAmbit/Services/APIService.cs
+++ b/sdk/AppAmbit/Services/APIService.cs
@@ -29,6 +29,12 @@ public class APIService : IAPIService
         try
         {
             var httpResponse = await RequestHttp(endpoint);
+
+            if (httpResponse.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                return ApiResult<T>.Fail(ApiErrorType.NotFound, "Resource not found");
+            }
+
             CheckStatusCodeFrom(httpResponse.StatusCode);
 
             var json = await httpResponse.Content.ReadAsStringAsync();
@@ -162,6 +168,11 @@ public class APIService : IAPIService
         httpClient.DefaultRequestHeaders
             .Accept
             .Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            
+        // httpClient.DefaultRequestHeaders.CacheControl = new CacheControlHeaderValue 
+        // { 
+        //     NoCache = true 
+        // };
 
         var responseMessage = await HttpResponseMessage(endpoint, httpClient);
         return responseMessage;
@@ -199,11 +210,15 @@ public class APIService : IAPIService
         _token = token;
     }
 
-    private T TryDeserializeJson<T>(string response)
+    private T? TryDeserializeJson<T>(string json)
     {
         try
         {
-            return JsonConvert.DeserializeObject<T>(response);
+            var settings = new JsonSerializerSettings
+            {
+                DateParseHandling = DateParseHandling.None
+            };
+            return JsonConvert.DeserializeObject<T>(json, settings);
         }
         catch (JsonException)
         {
@@ -215,14 +230,22 @@ public class APIService : IAPIService
     private async Task<HttpResponseMessage> HttpResponseMessage(IEndpoint endpoint, HttpClient client)
     {
         client.Timeout = TimeSpan.FromSeconds(10);
-        await AddAuthorizationHeaderIfNeeded(client);
+        AddAuthorizationHeaderIfNeeded(client, endpoint);
 
         var fullUrl = endpoint.BaseUrl + endpoint.Url;
         return await GetHttpResponseMessage(endpoint, client, fullUrl, endpoint.Payload);
     }
 
-    private async Task AddAuthorizationHeaderIfNeeded(HttpClient client)
+    private void AddAuthorizationHeaderIfNeeded(HttpClient client, IEndpoint endpoint)
     {
+        if (endpoint is CmsEndpoint)
+        {
+            var appKey = AppAmbitSdk.AppKey;
+            if (!string.IsNullOrEmpty(appKey))
+                client.DefaultRequestHeaders.TryAddWithoutValidation("X-App-Key", appKey);
+            return;
+        }
+
         var token = GetToken();
         if (!string.IsNullOrEmpty(token))
         {
@@ -312,7 +335,7 @@ private string SerializeStringPayload(object payload)
     private string SerializedGetURL(string url, object payload)
     {
         var serializedParameters = SerializeStringPayload(payload);
-        if (serializedParameters == null)
+        if (string.IsNullOrEmpty(serializedParameters))
         {
             return url;
         }

--- a/sdk/AppAmbit/Services/Endpoints/Base/BaseEndpoint.cs
+++ b/sdk/AppAmbit/Services/Endpoints/Base/BaseEndpoint.cs
@@ -6,7 +6,7 @@ internal class BaseEndpoint : IEndpoint
 {
     public string Url { get; set; }
     
-    public string BaseUrl { get; set; } = "https://appambit.com/api";
+    public virtual string BaseUrl { get; set; } = AppConstants.BaseUrlSdk;
      
     public bool SkipAuthorization { get; set;  } = false;
     

--- a/sdk/AppAmbit/Services/Endpoints/CmsEndpoints.cs
+++ b/sdk/AppAmbit/Services/Endpoints/CmsEndpoints.cs
@@ -1,0 +1,15 @@
+using AppAmbit.Services.Endpoints.Base;
+using AppAmbit.Services.Interfaces;
+
+namespace AppAmbit.Services.Endpoints;
+
+internal class CmsEndpoint : BaseEndpoint
+{
+    public override string BaseUrl => AppConstants.CmsBaseUrl;
+
+    public CmsEndpoint(string slug, int page, int perPage)
+    {
+        this.Method = HttpMethodEnum.Get;
+        this.Url = "/" + slug + $"/?per_page={perPage}&page={page}";
+    }
+}

--- a/sdk/AppAmbit/Services/Interfaces/ICms.cs
+++ b/sdk/AppAmbit/Services/Interfaces/ICms.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+
+namespace AppAmbit.Services.Interfaces;
+
+public interface ICms
+{
+    ICmsQueryBuilder<T> Content<T>(string contentType) where T : class;
+    Task ClearCache(string contentType);
+    Task ClearAllCache();
+}

--- a/sdk/AppAmbit/Services/Interfaces/ICmsQueryBuilder.cs
+++ b/sdk/AppAmbit/Services/Interfaces/ICmsQueryBuilder.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace AppAmbit;
+
+public interface ICmsQueryBuilder<T> where T : class
+{
+    ICmsQueryBuilder<T> Search(string query);
+    ICmsQueryBuilder<T> Equals(string field, string value);
+    ICmsQueryBuilder<T> NotEquals(string field, string value);
+    ICmsQueryBuilder<T> Contains(string field, string value);
+    ICmsQueryBuilder<T> StartsWith(string field, string value);
+    ICmsQueryBuilder<T> GreaterThan(string field, object value);
+    ICmsQueryBuilder<T> GreaterThanOrEqual(string field, object value);
+    ICmsQueryBuilder<T> LessThan(string field, object value);
+    ICmsQueryBuilder<T> LessThanOrEqual(string field, object value);
+    ICmsQueryBuilder<T> InList(string field, IEnumerable<string> values);
+    ICmsQueryBuilder<T> NotInList(string field, IEnumerable<string> values);
+    ICmsQueryBuilder<T> OrderByAscending(string field);
+    ICmsQueryBuilder<T> OrderByDescending(string field);
+    ICmsQueryBuilder<T> GetPage(int page);
+    ICmsQueryBuilder<T> GetPerPage(int perPage);
+    Task<List<T>> GetListAsync();
+}

--- a/sdk/AppAmbit/Services/Interfaces/IStorageService.cs
+++ b/sdk/AppAmbit/Services/Interfaces/IStorageService.cs
@@ -1,5 +1,6 @@
 using AppAmbit.Models.Analytics;
 using AppAmbit.Models.Breadcrumbs;
+using AppAmbit.Models.Cms;
 using AppAmbit.Models.Logs;
 using AppAmbit.Models.RemoteConfigs;
 
@@ -81,5 +82,13 @@ public interface IStorageService
     #region RemoteConfig
     Task AddConfigsAsync(List<RemoteConfigEntity> configs);
     Task<String?> GetConfig(String key);
+    #endregion
+
+    #region CMS
+    Task<CmsCacheEntity?> GetCmsEntryAsync(string contentType);
+    Task UpsertCmsEntryAsync(CmsCacheEntity entry);
+    Task DeleteCmsEntryAsync(string contentType);
+    Task DeleteAllCmsEntriesAsync();
+    Task<List<string>> QueryCmsDataAsync(string contentType, string? filterClause, string[]? selectionArgs, string? orderBy, int limit, int offset);
     #endregion
 }

--- a/sdk/AppAmbit/Services/Interfaces/IStorageService.cs
+++ b/sdk/AppAmbit/Services/Interfaces/IStorageService.cs
@@ -87,6 +87,7 @@ public interface IStorageService
     #region CMS
     Task<CmsCacheEntity?> GetCmsEntryAsync(string contentType);
     Task UpsertCmsEntryAsync(CmsCacheEntity entry);
+    Task UpsertCmsEntryIfChangedAsync(string contentType, string remoteJson);
     Task DeleteCmsEntryAsync(string contentType);
     Task DeleteAllCmsEntriesAsync();
     Task<List<string>> QueryCmsDataAsync(string contentType, string? filterClause, string[]? selectionArgs, string? orderBy, int limit, int offset);

--- a/sdk/AppAmbit/Services/StorageService.cs
+++ b/sdk/AppAmbit/Services/StorageService.cs
@@ -559,6 +559,23 @@ public class StorageService : IStorageService
         await _database.InsertOrReplaceAsync(entry).ConfigureAwait(false);
     }
 
+    public async Task UpsertCmsEntryIfChangedAsync(string contentType, string remoteJson)
+    {
+        var local = await GetCmsEntryAsync(contentType).ConfigureAwait(false);
+
+        if (local != null &&
+            local.JsonData?.Length == remoteJson.Length &&
+            string.Equals(local.JsonData, remoteJson, StringComparison.Ordinal))
+            return;
+
+        await UpsertCmsEntryAsync(new CmsCacheEntity
+        {
+            ContentType  = contentType,
+            JsonData     = remoteJson,
+            LastSyncedAt = DateTimeOffset.UtcNow.ToUnixTimeSeconds()
+        }).ConfigureAwait(false);
+    }
+
     public async Task DeleteCmsEntryAsync(string contentType)
     {
         await _database.Table<CmsCacheEntity>()
@@ -572,10 +589,21 @@ public class StorageService : IStorageService
         await _database.DeleteAllAsync<CmsCacheEntity>().ConfigureAwait(false);
     }
 
+    public static string BuildListClause(string field, bool exists, int valueCount)
+    {
+        var placeholders = string.Join(",", Enumerable.Repeat("?", valueCount));
+        var prefix = exists ? "EXISTS" : "NOT EXISTS";
+        return $"{prefix} (SELECT 1 FROM json_each(" +
+               $"CASE WHEN json_type(e.value, '$.{field}') = 'array' " +
+               $"THEN json_extract(e.value, '$.{field}') " +
+               $"ELSE json_array(json_extract(e.value, '$.{field}')) END) AS je " +
+               $"WHERE je.value IN ({placeholders}))";
+    }
+
     public async Task<List<string>> QueryCmsDataAsync(string contentType, string? filterClause, string[]? selectionArgs, string? orderBy, int limit, int offset)
     {
         var results = new List<string>();
-        var query = "SELECT json_extract(value, '$') FROM CmsEntries, json_each(JsonData, '$.data') WHERE ContentType = ?";
+        var query = "SELECT json_extract(e.value, '$') FROM CmsEntries, json_each(JsonData, '$.data') AS e WHERE ContentType = ?";
 
         if (!string.IsNullOrEmpty(filterClause))
             query += " AND (" + filterClause + ")";
@@ -596,7 +624,21 @@ public class StorageService : IStorageService
         for (int i = 0; i < extraArgs.Length; i++)
             args[i + 1] = extraArgs[i];
 
+        Debug.WriteLine($"[AppAmbit.Cms] SQL: {query}");
+        Debug.WriteLine($"[AppAmbit.Cms] Args: [{string.Join(", ", args)}]");
+
         var rows = await _database.QueryScalarsAsync<string>(query, args).ConfigureAwait(false);
+
+        Debug.WriteLine($"[AppAmbit.Cms] Results count: {rows?.Count ?? 0}");
+        if (rows != null && rows.Count > 0)
+        {
+            for (int i = 0; i < Math.Min(rows.Count, 5); i++)
+            {
+                var preview = rows[i]?.Length > 80 ? rows[i]![..80] + "..." : rows[i];
+                Debug.WriteLine($"[AppAmbit.Cms] Row[{i}]: {preview}");
+            }
+        }
+
         return rows ?? results;
     }
 

--- a/sdk/AppAmbit/Services/StorageService.cs
+++ b/sdk/AppAmbit/Services/StorageService.cs
@@ -3,6 +3,7 @@ using AppAmbit.Enums;
 using AppAmbit.Models.Analytics;
 using AppAmbit.Models.App;
 using AppAmbit.Models.Breadcrumbs;
+using AppAmbit.Models.Cms;
 using AppAmbit.Models.Logs;
 using AppAmbit.Models.RemoteConfigs;
 using AppAmbit.Services.Interfaces;
@@ -29,6 +30,7 @@ public class StorageService : IStorageService
         await _database.CreateTableAsync<SessionBatch>();
         await _database.CreateTableAsync<BreadcrumbsEntity>();
         await _database.CreateTableAsync<RemoteConfigEntity>();
+        await _database.CreateTableAsync<CmsCacheEntity>();
         await EnsureAppSecretsColumns();
     }
 
@@ -540,4 +542,63 @@ public class StorageService : IStorageService
             .FirstOrDefaultAsync();
         return config?.Value;
     }
+
+    #region CMS
+
+    public async Task<CmsCacheEntity?> GetCmsEntryAsync(string contentType)
+    {
+        return await _database.Table<CmsCacheEntity>()
+            .Where(c => c.ContentType == contentType)
+            .FirstOrDefaultAsync()
+            .ConfigureAwait(false);
+    }
+
+    public async Task UpsertCmsEntryAsync(CmsCacheEntity entry)
+    {
+        if (entry == null) return;
+        await _database.InsertOrReplaceAsync(entry).ConfigureAwait(false);
+    }
+
+    public async Task DeleteCmsEntryAsync(string contentType)
+    {
+        await _database.Table<CmsCacheEntity>()
+            .Where(x => x.ContentType == contentType)
+            .DeleteAsync()
+            .ConfigureAwait(false);
+    }
+
+    public async Task DeleteAllCmsEntriesAsync()
+    {
+        await _database.DeleteAllAsync<CmsCacheEntity>().ConfigureAwait(false);
+    }
+
+    public async Task<List<string>> QueryCmsDataAsync(string contentType, string? filterClause, string[]? selectionArgs, string? orderBy, int limit, int offset)
+    {
+        var results = new List<string>();
+        var query = "SELECT json_extract(value, '$') FROM CmsEntries, json_each(JsonData, '$.data') WHERE ContentType = ?";
+
+        if (!string.IsNullOrEmpty(filterClause))
+            query += " AND (" + filterClause + ")";
+
+        if (!string.IsNullOrEmpty(orderBy))
+            query += " ORDER BY " + orderBy;
+
+        if (limit > 0)
+        {
+            query += " LIMIT " + limit;
+            if (offset > 0)
+                query += " OFFSET " + offset;
+        }
+
+        var extraArgs = selectionArgs ?? Array.Empty<string>();
+        var args = new object[extraArgs.Length + 1];
+        args[0] = contentType;
+        for (int i = 0; i < extraArgs.Length; i++)
+            args[i + 1] = extraArgs[i];
+
+        var rows = await _database.QueryScalarsAsync<string>(query, args).ConfigureAwait(false);
+        return rows ?? results;
+    }
+
+    #endregion
 }

--- a/tests/AnalyticsExamples.cs
+++ b/tests/AnalyticsExamples.cs
@@ -8,6 +8,7 @@ using AppAmbit.Models.Responses;
 using AppAmbit.Services;
 using AppAmbit.Services.Interfaces;
 using AppAmbit.Models.RemoteConfigs;
+using AppAmbit.Models.Cms;
 
 namespace AppAmbitTest;
 
@@ -277,7 +278,7 @@ public class AnalyticsExamples : IDisposable
         }
     }
 
-    private sealed class FakeStorageService : IStorageService
+    private sealed class FakeStorageService : BaseFakeStorageService
     {
         private string? _pushDeviceToken;
         private bool? _pushEnabled;
@@ -286,20 +287,13 @@ public class AnalyticsExamples : IDisposable
         public List<LogEntity> Logs { get; } = new();
         public List<EventEntity> Events { get; } = new();
 
-        public Task InitializeAsync() => Task.CompletedTask;
-
-        public Task SessionData(SessionData sessionData)
+        public override Task SessionData(SessionData sessionData)
         {
             Sessions.Add(sessionData);
             return Task.CompletedTask;
         }
 
-        public Task<List<SessionBatch>> GetOldest100SessionsAsync() => Task.FromResult(new List<SessionBatch>());
-        public Task DeleteSessionsList(List<SessionBatch> sessions) => Task.CompletedTask;
-        public Task<SessionData?> GetUnpairedSessionStart() => Task.FromResult<SessionData?>(null);
-        public Task<SessionData?> GetUnpairedSessionEnd() => Task.FromResult<SessionData?>(null);
-        public Task DeleteSessionById(string id) => Task.CompletedTask;
-        public Task UpdateSessionIdsForAllTrackingData(List<SessionBatch> sessions)
+        public override Task UpdateSessionIdsForAllTrackingData(List<SessionBatch> sessions)
         {
             foreach (var session in sessions)
             {
@@ -329,46 +323,35 @@ public class AnalyticsExamples : IDisposable
             return Task.CompletedTask;
         }
 
-        public Task SetDeviceId(string? deviceId) => Task.CompletedTask;
-        public Task<string?> GetDeviceId() => Task.FromResult<string?>(null);
-        public Task SetUserId(string userId) => Task.CompletedTask;
-        public Task<string?> GetUserId() => Task.FromResult<string?>(null);
-        public Task SetUserEmail(string? email) => Task.CompletedTask;
-        public Task<string?> GetUserEmail() => Task.FromResult<string?>(null);
-        public Task SetAppId(string? appId) => Task.CompletedTask;
-        public Task<string?> GetAppId() => Task.FromResult<string?>(null);
-        public Task<string?> GetConsumerId() => Task.FromResult<string?>(null);
-        public Task SetConsumerId(string consumerId) => Task.CompletedTask;
-        public Task<string?> GetPushDeviceToken() => Task.FromResult(_pushDeviceToken);
-        public Task SetPushDeviceToken(string? token)
+        public override Task<string?> GetPushDeviceToken() => Task.FromResult(_pushDeviceToken);
+        public override Task SetPushDeviceToken(string? token)
         {
             _pushDeviceToken = token;
             return Task.CompletedTask;
         }
-        public Task<bool?> GetPushEnabled() => Task.FromResult(_pushEnabled);
-        public Task SetPushEnabled(bool enabled)
+        public override Task<bool?> GetPushEnabled() => Task.FromResult(_pushEnabled);
+        public override Task SetPushEnabled(bool enabled)
         {
             _pushEnabled = enabled;
             return Task.CompletedTask;
         }
 
-        public Task<List<LogEntity>> GetOldest100LogsAsync() => Task.FromResult(Logs.ToList());
-        public Task LogEventAsync(LogEntity logEntity)
+        public override Task<List<LogEntity>> GetOldest100LogsAsync() => Task.FromResult(Logs.ToList());
+        public override Task LogEventAsync(LogEntity logEntity)
         {
             Logs.Add(logEntity);
             return Task.CompletedTask;
         }
-        public Task DeleteLogList(List<LogEntity> logs) => Task.CompletedTask;
 
-        public Task LogAnalyticsEventAsync(EventEntity analyticsLog)
+        public override Task LogAnalyticsEventAsync(EventEntity analyticsLog)
         {
             Events.Add(analyticsLog);
             return Task.CompletedTask;
         }
 
-        public Task<List<EventEntity>> GetOldest100EventsAsync() => Task.FromResult(Events.ToList());
+        public override Task<List<EventEntity>> GetOldest100EventsAsync() => Task.FromResult(Events.ToList());
 
-        public Task DeleteEventList(List<EventEntity> logs)
+        public override Task DeleteEventList(List<EventEntity> logs)
         {
             foreach (var e in logs)
             {
@@ -377,16 +360,12 @@ public class AnalyticsExamples : IDisposable
             return Task.CompletedTask;
         }
 
-        public Task<List<BreadcrumbsEntity>> GetOldest100BreadcrumbsAsync() => Task.FromResult(Breadcrumbs.ToList());
-        public Task AddBreadcrumbAsync(BreadcrumbsEntity breadcrumb)
+        public override Task<List<BreadcrumbsEntity>> GetOldest100BreadcrumbsAsync() => Task.FromResult(Breadcrumbs.ToList());
+        public override Task AddBreadcrumbAsync(BreadcrumbsEntity breadcrumb)
         {
             Breadcrumbs.Add(breadcrumb);
             return Task.CompletedTask;
         }
-        public Task DeleteBreadcrumbs(List<BreadcrumbsEntity> breadcrumbs) => Task.CompletedTask;
-
-        public Task AddConfigsAsync(List<RemoteConfigEntity> configs) => Task.CompletedTask;
-        public Task<string?> GetConfig(string key) => Task.FromResult<string?>(null);
     }
 
     private sealed class FakeAppInfoService : IAppInfoService

--- a/tests/BaseFakeStorageService.cs
+++ b/tests/BaseFakeStorageService.cs
@@ -1,0 +1,68 @@
+using AppAmbit.Models.Analytics;
+using AppAmbit.Models.Breadcrumbs;
+using AppAmbit.Models.Cms;
+using AppAmbit.Models.Logs;
+using AppAmbit.Models.RemoteConfigs;
+using AppAmbit.Models.Responses;
+using AppAmbit.Services.Interfaces;
+
+namespace AppAmbitTest;
+
+internal abstract class BaseFakeStorageService : IStorageService
+{
+    public virtual Task InitializeAsync() => Task.CompletedTask;
+
+    // Session Data
+    public virtual Task SessionData(SessionData sessionData) => Task.CompletedTask;
+    public virtual Task<List<SessionBatch>> GetOldest100SessionsAsync() => Task.FromResult(new List<SessionBatch>());
+    public virtual Task DeleteSessionsList(List<SessionBatch> sessions) => Task.CompletedTask;
+    public virtual Task<SessionData?> GetUnpairedSessionStart() => Task.FromResult<SessionData?>(null);
+    public virtual Task<SessionData?> GetUnpairedSessionEnd() => Task.FromResult<SessionData?>(null);
+    public virtual Task DeleteSessionById(string id) => Task.CompletedTask;
+    public virtual Task UpdateSessionIdsForAllTrackingData(List<SessionBatch> sessions) => Task.CompletedTask;
+
+    // Device / User / App Info
+    public virtual Task SetDeviceId(string? deviceId) => Task.CompletedTask;
+    public virtual Task<string?> GetDeviceId() => Task.FromResult<string?>(null);
+    public virtual Task SetUserId(string userId) => Task.CompletedTask;
+    public virtual Task<string?> GetUserId() => Task.FromResult<string?>(null);
+    public virtual Task SetUserEmail(string? email) => Task.CompletedTask;
+    public virtual Task<string?> GetUserEmail() => Task.FromResult<string?>(null);
+    public virtual Task SetAppId(string? appId) => Task.CompletedTask;
+    public virtual Task<string?> GetAppId() => Task.FromResult<string?>(null);
+    public virtual Task<string?> GetConsumerId() => Task.FromResult<string?>(null);
+    public virtual Task SetConsumerId(string consumerId) => Task.CompletedTask;
+
+    // Push Notifications
+    public virtual Task<string?> GetPushDeviceToken() => Task.FromResult<string?>(null);
+    public virtual Task SetPushDeviceToken(string? token) => Task.CompletedTask;
+    public virtual Task<bool?> GetPushEnabled() => Task.FromResult<bool?>(null);
+    public virtual Task SetPushEnabled(bool enabled) => Task.CompletedTask;
+
+    // Logs
+    public virtual Task<List<LogEntity>> GetOldest100LogsAsync() => Task.FromResult(new List<LogEntity>());
+    public virtual Task LogEventAsync(LogEntity logEntity) => Task.CompletedTask;
+    public virtual Task DeleteLogList(List<LogEntity> logs) => Task.CompletedTask;
+
+    // Analytics Events
+    public virtual Task LogAnalyticsEventAsync(EventEntity analyticsLog) => Task.CompletedTask;
+    public virtual Task<List<EventEntity>> GetOldest100EventsAsync() => Task.FromResult(new List<EventEntity>());
+    public virtual Task DeleteEventList(List<EventEntity> logs) => Task.CompletedTask;
+
+    // Breadcrumbs
+    public virtual Task<List<BreadcrumbsEntity>> GetOldest100BreadcrumbsAsync() => Task.FromResult(new List<BreadcrumbsEntity>());
+    public virtual Task AddBreadcrumbAsync(BreadcrumbsEntity breadcrumb) => Task.CompletedTask;
+    public virtual Task DeleteBreadcrumbs(List<BreadcrumbsEntity> breadcrumbs) => Task.CompletedTask;
+
+    // Remote Configs
+    public virtual Task AddConfigsAsync(List<RemoteConfigEntity> configs) => Task.CompletedTask;
+    public virtual Task<string?> GetConfig(string key) => Task.FromResult<string?>(null);
+
+    // CMS
+    public virtual Task<CmsCacheEntity?> GetCmsEntryAsync(string contentType) => Task.FromResult<CmsCacheEntity?>(null);
+    public virtual Task UpsertCmsEntryAsync(CmsCacheEntity entry) => Task.CompletedTask;
+    public virtual Task DeleteCmsEntryAsync(string contentType) => Task.CompletedTask;
+    public virtual Task DeleteAllCmsEntriesAsync() => Task.CompletedTask;
+    public virtual Task<List<string>> QueryCmsDataAsync(string contentType, string? filterClause, string[]? selectionArgs, string? orderBy, int limit, int offset) 
+        => Task.FromResult(new List<string>());
+}

--- a/tests/BaseFakeStorageService.cs
+++ b/tests/BaseFakeStorageService.cs
@@ -61,6 +61,7 @@ internal abstract class BaseFakeStorageService : IStorageService
     // CMS
     public virtual Task<CmsCacheEntity?> GetCmsEntryAsync(string contentType) => Task.FromResult<CmsCacheEntity?>(null);
     public virtual Task UpsertCmsEntryAsync(CmsCacheEntity entry) => Task.CompletedTask;
+    public virtual Task UpsertCmsEntryIfChangedAsync(string contentType, string remoteJson) => Task.CompletedTask;
     public virtual Task DeleteCmsEntryAsync(string contentType) => Task.CompletedTask;
     public virtual Task DeleteAllCmsEntriesAsync() => Task.CompletedTask;
     public virtual Task<List<string>> QueryCmsDataAsync(string contentType, string? filterClause, string[]? selectionArgs, string? orderBy, int limit, int offset) 

--- a/tests/CrashesExamples.cs
+++ b/tests/CrashesExamples.cs
@@ -8,6 +8,7 @@ using AppAmbit.Models.Responses;
 using AppAmbit.Services;
 using AppAmbit.Services.Interfaces;
 using AppAmbit.Models.RemoteConfigs;
+using AppAmbit.Models.Cms;
 
 namespace AppAmbitTest;
 
@@ -195,7 +196,7 @@ public class CrashesExamples : IDisposable
         }
     }
 
-    private sealed class FakeStorageService : IStorageService
+    private sealed class FakeStorageService : BaseFakeStorageService
     {
         private string? _pushDeviceToken;
         private bool? _pushEnabled;
@@ -204,33 +205,13 @@ public class CrashesExamples : IDisposable
         public List<LogEntity> Logs { get; } = new();
         public List<EventEntity> Events { get; } = new();
 
-        public Task InitializeAsync() => Task.CompletedTask;
-
-        public Task SessionData(SessionData sessionData)
+        public override Task SessionData(SessionData sessionData)
         {
             Sessions.Add(sessionData);
             return Task.CompletedTask;
         }
 
-        public Task<List<SessionBatch>> GetOldest100SessionsAsync() => Task.FromResult(new List<SessionBatch>());
-
-        public Task DeleteSessionsList(List<SessionBatch> sessions)
-        {
-            Sessions.RemoveAll(s => sessions.Any(x => x.Id == s.Id));
-            return Task.CompletedTask;
-        }
-
-        public Task<SessionData?> GetUnpairedSessionStart() => Task.FromResult<SessionData?>(Sessions.FirstOrDefault(s => s.SessionType == SessionType.Start));
-
-        public Task<SessionData?> GetUnpairedSessionEnd() => Task.FromResult<SessionData?>(Sessions.FirstOrDefault(s => s.SessionType == SessionType.End));
-
-        public Task DeleteSessionById(string id)
-        {
-            Sessions.RemoveAll(s => s.Id == id);
-            return Task.CompletedTask;
-        }
-
-        public Task UpdateSessionIdsForAllTrackingData(List<SessionBatch> sessions)
+        public override Task UpdateSessionIdsForAllTrackingData(List<SessionBatch> sessions)
         {
             foreach (var sb in sessions)
             {
@@ -242,36 +223,26 @@ public class CrashesExamples : IDisposable
             return Task.CompletedTask;
         }
 
-        public Task SetDeviceId(string? deviceId) => Task.CompletedTask;
-        public Task<string?> GetDeviceId() => Task.FromResult<string?>(null);
-        public Task SetUserId(string userId) => Task.CompletedTask;
-        public Task<string?> GetUserId() => Task.FromResult<string?>(null);
-        public Task SetUserEmail(string? email) => Task.CompletedTask;
-        public Task<string?> GetUserEmail() => Task.FromResult<string?>(null);
-        public Task SetAppId(string? appId) => Task.CompletedTask;
-        public Task<string?> GetAppId() => Task.FromResult<string?>(null);
-        public Task<string?> GetConsumerId() => Task.FromResult<string?>(null);
-        public Task SetConsumerId(string consumerId) => Task.CompletedTask;
-        public Task<string?> GetPushDeviceToken() => Task.FromResult(_pushDeviceToken);
-        public Task SetPushDeviceToken(string? token)
+        public override Task<string?> GetPushDeviceToken() => Task.FromResult(_pushDeviceToken);
+        public override Task SetPushDeviceToken(string? token)
         {
             _pushDeviceToken = token;
             return Task.CompletedTask;
         }
-        public Task<bool?> GetPushEnabled() => Task.FromResult(_pushEnabled);
-        public Task SetPushEnabled(bool enabled)
+        public override Task<bool?> GetPushEnabled() => Task.FromResult(_pushEnabled);
+        public override Task SetPushEnabled(bool enabled)
         {
             _pushEnabled = enabled;
             return Task.CompletedTask;
         }
 
-        public Task<List<LogEntity>> GetOldest100LogsAsync() => Task.FromResult(Logs.ToList());
-        public Task LogEventAsync(LogEntity logEntity)
+        public override Task<List<LogEntity>> GetOldest100LogsAsync() => Task.FromResult(Logs.ToList());
+        public override Task LogEventAsync(LogEntity logEntity)
         {
             Logs.Add(logEntity);
             return Task.CompletedTask;
         }
-        public Task DeleteLogList(List<LogEntity> logs)
+        public override Task DeleteLogList(List<LogEntity> logs)
         {
             foreach (var log in logs)
             {
@@ -280,24 +251,19 @@ public class CrashesExamples : IDisposable
             return Task.CompletedTask;
         }
 
-        public Task LogAnalyticsEventAsync(EventEntity analyticsLog)
+        public override Task LogAnalyticsEventAsync(EventEntity analyticsLog)
         {
             Events.Add(analyticsLog);
             return Task.CompletedTask;
         }
-        public Task<List<EventEntity>> GetOldest100EventsAsync() => Task.FromResult(Events.ToList());
-        public Task DeleteEventList(List<EventEntity> logs) => Task.CompletedTask;
+        public override Task<List<EventEntity>> GetOldest100EventsAsync() => Task.FromResult(Events.ToList());
 
-        public Task<List<BreadcrumbsEntity>> GetOldest100BreadcrumbsAsync() => Task.FromResult(Breadcrumbs.ToList());
-        public Task AddBreadcrumbAsync(BreadcrumbsEntity breadcrumb)
+        public override Task<List<BreadcrumbsEntity>> GetOldest100BreadcrumbsAsync() => Task.FromResult(Breadcrumbs.ToList());
+        public override Task AddBreadcrumbAsync(BreadcrumbsEntity breadcrumb)
         {
             Breadcrumbs.Add(breadcrumb);
             return Task.CompletedTask;
         }
-        public Task DeleteBreadcrumbs(List<BreadcrumbsEntity> breadcrumbs) => Task.CompletedTask;
-
-        public Task AddConfigsAsync(List<RemoteConfigEntity> configs) => Task.CompletedTask;
-        public Task<string?> GetConfig(string key) => Task.FromResult<string?>(null);
     }
 
     private sealed class FakeAppInfoService : IAppInfoService


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🛠️ Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📚 Documentation Update

## Description

Optimization and hardening of the **CMS Cache Engine** in the .NET SDK, building on top of the previously merged Stale-While-Revalidate (SWR) implementation.

**Cache Invalidation (Page 1 Rules)**
The SDK now evaluates the **first page** of a remote request before writing to SQLite. If the server responds with a `404 Not Found` (content type deleted/unpublished) or returns `data: [], total: 0` (all entries removed), the SDK automatically deletes the local SQLite row for that `content_type`. Network errors (5xx, offline) preserve the local cache to ensure offline availability.

**Hash-Based Change Detection (Zero-Allocation)**
`LastSyncedAt` and the SQLite row are only updated when there is a real data change. The check uses a tiered zero-allocation comparison:
1. **Length diff** → O(1), exits immediately if string lengths differ (covers 90% of add/delete cases).
2. **Ordinal string equality** → O(n), no byte-array allocation (outperforms MD5 on large payloads).

This avoids unnecessary SQLite writes on every background refresh cycle.

**Per-Content-Type Concurrency (SemaphoreSlim)**
A `ConcurrentDictionary<string, SemaphoreSlim>` in `Cms.cs` assigns one semaphore per `content_type`. Background refreshes triggered by burst calls to `GetListAsync()` use `WaitAsync(0)` (non-blocking), ensuring only one network + write operation runs per collection at a time — preventing race conditions without blocking the UI thread.

**Manual Cache Management**
Two methods exposed on `Cms` for developer control:
```csharp
// Clear a single orphaned collection
await Cms.Clear("tech_inventory");

// Full cache reset (e.g. logout, re-login)
await Cms.ClearAll();
```

**Test Infrastructure Refactor**
- Introduced `BaseFakeStorageService`: a shared base class for `IStorageService` stubs, eliminating ~200 lines of duplicated code across `AnalyticsExamples` and `CrashesExamples`.
- `CmsQueryBuilderTests` now has 13 unit tests (zero inline comments) covering: filters, ordering, pagination, invalidation (404 & empty), hash-based no-op refresh, concurrent SemaphoreSlim guard, and `Clear/ClearAll`.

**Filters available in the sample app dropdown:**
- Equals: `item_sku = TEC-02`
- Not Equals: `item_sku ≠ TEC-02`
- Contains: `product_name` contains `'Pro'`
- Starts With: `item_sku` starts with `'TEC'`
- In List: `item_sku` in `[TEC-01, TEC-02]`
- Not In List: `item_sku` not in `[TEC-01, TEC-02]`
- Greater Than: `price > 100`
- Greater Or Equal: `price >= 100`
- Less Than: `price < 100`
- Less Or Equal: `price <= 100`
- Order By `product_name` ASC
- Order By `product_name` DESC
- Pagination: Page 1, 2 per page
- Pagination: Page 2, 2 per page

## Related Tickets & Documents

- [ID-1574](https://app.asana.com/1/1203353714760101/project/1204450899416459/task/1213724761064772)
- Closes #1574

## QA Instructions, Screenshots, Recordings

1. Initialize the SDK with `.UseAppAmbit("APP_KEY")` in `MauiProgram.cs`.¿
2. Navigate to `CmsPage` in the sample app.
3. Press **"Fetch List"** — the first time, it downloads and caches data in SQLite.
4. Press it again — it instantly returns the cache and initiates a background refresh.
5. Modify a field on the server (e.g., `price`) and press **"Fetch List"** again — on the second call, you should see the updated data.
6. Remove `content_type` from the panel and call it again — the SDK should automatically clear the SQLite row.
7. Call `Cms.Clear("tech_inventory")` and press Enter — this should force a fresh network query.
8. Verify that filters in Picker (Equals, Contains, OrderBy, SetPage) return correct subsets.


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] ✅ Yes  
- [X] ❌ No, and this is why:
- [ ] 🤔 I need help with writing tests

## Are there any post deployment tasks we need to perform?
- [ ] 📝 Yes (please add details).
- [X] ❌ No
- [ ] ❓ I don't know
 
## [optional] What gif best describes this PR or how it makes you feel?
![Alt Text](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExdDN6emxic3ZpdHV1dndtNW1sYWlqc20xdWZqdWd0ZDY4a3p4OGtidCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/KkZPnRUQ7o8u5WWfQc/giphy.gif)