### PR TITLE
ID-1652: Feature - Add db

### DIFF
--- a/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Models/TaskModel.cs
+++ b/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Models/TaskModel.cs
@@ -1,0 +1,12 @@
+using AppAmbit.Attributes;
+
+namespace AppAmbitTestingAppAvalonia.Models;
+
+public class TaskModel
+{
+    public int Id { get; set; }
+    public string? Title { get; set; }
+    [DbColumn("is_completed")] public int IsCompleted { get; set; }
+    public string? Priority { get; set; }
+    [DbColumn("due_date")] public string? DueDate { get; set; }
+}

--- a/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Views/DatabaseView.axaml
+++ b/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Views/DatabaseView.axaml
@@ -1,0 +1,82 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="420" d:DesignHeight="700"
+             x:Class="AppAmbitTestingAppAvalonia.Views.DatabaseView">
+
+  <Grid RowDefinitions="Auto,*">
+
+    <!-- Controls -->
+    <StackPanel Grid.Row="0" Margin="16" Spacing="10">
+
+      <TextBlock Text="Database"
+                 FontSize="20"
+                 FontWeight="Bold"
+                 HorizontalAlignment="Center" />
+
+      <!-- SQL editor -->
+      <TextBox x:Name="EditSql"
+               Text="SELECT * FROM tasks LIMIT 10"
+               FontFamily="Courier New,Consolas,monospace"
+               FontSize="13"
+               AcceptsReturn="True"
+               Height="70"
+               Watermark="SELECT * FROM tasks LIMIT 10" />
+
+      <!-- Function picker + Run -->
+      <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+        <ComboBox x:Name="FunctionPicker"
+                  Grid.Column="0"
+                  HorizontalAlignment="Stretch"
+                  PlaceholderText="Select a function..." />
+        <Button Grid.Column="1"
+                Content="▶ Run"
+                Click="OnRunClicked"
+                MinWidth="80" />
+      </Grid>
+
+      <!-- Status bar -->
+      <Border x:Name="StatusBorder"
+              CornerRadius="6"
+              Padding="10,6"
+              IsVisible="False">
+        <TextBlock x:Name="TxtStatus"
+                   FontSize="12"
+                   TextWrapping="Wrap" />
+      </Border>
+
+      <!-- Loading bar -->
+      <ProgressBar x:Name="LoadingBar"
+                   IsIndeterminate="True"
+                   IsVisible="False"
+                   Height="3" />
+
+    </StackPanel>
+
+    <!-- Results -->
+    <ScrollViewer Grid.Row="1" Margin="0,0,0,0">
+      <ItemsControl x:Name="ResultsList" Margin="16,0,16,16">
+        <ItemsControl.ItemTemplate>
+          <DataTemplate>
+            <Border Background="White"
+                    BorderBrush="#E0E0E0"
+                    BorderThickness="1"
+                    CornerRadius="6"
+                    Padding="10,8"
+                    Margin="0,3,0,0">
+              <ScrollViewer HorizontalScrollBarVisibility="Auto"
+                            VerticalScrollBarVisibility="Disabled">
+                <TextBlock Text="{Binding}"
+                           FontFamily="Courier New,Consolas,monospace"
+                           FontSize="12"
+                           Foreground="#212121" />
+              </ScrollViewer>
+            </Border>
+          </DataTemplate>
+        </ItemsControl.ItemTemplate>
+      </ItemsControl>
+    </ScrollViewer>
+
+  </Grid>
+</UserControl>

--- a/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Views/DatabaseView.axaml.cs
+++ b/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Views/DatabaseView.axaml.cs
@@ -1,0 +1,274 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AppAmbit;
+using AppAmbit.Models.Db;
+using AppAmbitTestingAppAvalonia.Models;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using Avalonia.Threading;
+
+namespace AppAmbitTestingAppAvalonia.Views;
+
+public partial class DatabaseView : UserControl
+{
+    private record DemoItem(string Label, Func<Task> Action);
+
+    private List<DemoItem> _demos = new();
+
+    public DatabaseView()
+    {
+        InitializeComponent();
+        BuildDemos();
+        FunctionPicker.ItemsSource = _demos.Select(d => d.Label).ToList();
+        FunctionPicker.SelectedIndex = 0;
+    }
+
+    private void BuildDemos()
+    {
+        _demos = new List<DemoItem>
+        {
+            new("Raw SQL → execute(sql)",                         RunExecute),
+            new("Raw SQL → execute(sql, params)",                 RunExecuteParams),
+            new("Batch → batch()",                                RunBatch),
+            new("Batch → batchInTransaction()",                   RunBatchInTransaction),
+            new("Fluent SELECT → select+where+orderByDesc+limit", RunFluentSelect),
+            new("Fluent SELECT → where(col,val)",                 RunWhereEquality),
+            new("Fluent SELECT → whereIn()",                      RunWhereIn),
+            new("Fluent SELECT → limit+offset",                   RunOffset),
+            new("Fluent SELECT → first()",                        RunFirst),
+            new("Fluent SELECT → count()",                        RunCount),
+            new("Fluent WRITE → insert()",                        RunInsert),
+            new("Fluent WRITE → update()",                        RunUpdate),
+            new("Fluent WRITE → delete()",                        RunDelete),
+            new("Typed Model → from(tasks, TaskModel.class)",     RunTypedModel),
+            new("Preset → List tables",                           RunPresetTables),
+            new("Preset → SELECT * WHERE priority='high'",        RunPresetHighPriority),
+        };
+    }
+
+    private async void OnRunClicked(object? sender, RoutedEventArgs e)
+    {
+        if (FunctionPicker.SelectedIndex < 0) return;
+        var demo = _demos[FunctionPicker.SelectedIndex];
+        SetLoading(true);
+        ShowStatus($"Running: {demo.Label}", false);
+        try { await demo.Action(); }
+        catch (Exception ex) { ShowStatus($"Error: {ex.Message}", true); }
+        finally { SetLoading(false); }
+    }
+
+    private void SetLoading(bool loading)
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            LoadingBar.IsVisible = loading;
+        });
+    }
+
+    private void ShowStatus(string message, bool isError)
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            StatusBorder.IsVisible = true;
+            StatusBorder.Background = isError
+                ? new SolidColorBrush(Color.Parse("#FFEBEE"))
+                : new SolidColorBrush(Color.Parse("#E8F5E9"));
+            TxtStatus.Foreground = isError
+                ? new SolidColorBrush(Color.Parse("#C62828"))
+                : new SolidColorBrush(Color.Parse("#1B5E20"));
+            TxtStatus.Text = message;
+        });
+    }
+
+    private void ShowRows(List<string> columns, List<Dictionary<string, object?>> rows)
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (rows.Count == 0)
+            {
+                ResultsList.ItemsSource = new List<string> { "(no rows)" };
+                return;
+            }
+            var lines = rows.Select(row =>
+                string.Join("   |   ", columns.Select(c =>
+                {
+                    var val = row.TryGetValue(c, out var v) ? v?.ToString() ?? "null" : "null";
+                    return $"{c}: {val}";
+                }))).ToList();
+            ResultsList.ItemsSource = lines;
+        });
+    }
+
+    // ── Raw Execute ───────────────────────────────────────────────────────────
+
+    private async Task RunExecute()
+    {
+        var sql = EditSql.Text?.Trim();
+        if (string.IsNullOrWhiteSpace(sql))
+        {
+            sql = "SELECT * FROM tasks LIMIT 10";
+            Dispatcher.UIThread.Post(() => EditSql.Text = sql);
+        }
+        var result = await AppAmbitDb.Execute(sql);
+        if (result.HasError) { ShowStatus($"Error: {result.Error}", true); return; }
+        ShowStatus($"execute(sql) — rows_read={result.RowsRead}  rows_written={result.RowsWritten}", false);
+        ShowRows(result.Columns, result.ToMaps());
+    }
+
+    private async Task RunExecuteParams()
+    {
+        var result = await AppAmbitDb.Execute("SELECT * FROM tasks WHERE is_completed = ? LIMIT ?", 0, 10);
+        if (result.HasError) { ShowStatus($"Error: {result.Error}", true); return; }
+        ShowStatus($"execute(sql, 0, 10) — rows_read={result.RowsRead}", false);
+        ShowRows(result.Columns, result.ToMaps());
+    }
+
+    // ── Batch ─────────────────────────────────────────────────────────────────
+
+    private async Task RunBatch()
+    {
+        var results = await AppAmbitDb.Batch(
+            DbStatement.Of("INSERT INTO tasks (title, is_completed, priority, due_date) VALUES (?, ?, ?, ?)", "Buy coffee", 0, "low", "2026-06-10"),
+            DbStatement.Of("INSERT INTO tasks (title, is_completed, priority, due_date) VALUES (?, ?, ?, ?)", "Review PR", 0, "high", "2026-06-05"),
+            DbStatement.Of("SELECT COUNT(*) AS total FROM tasks"));
+        int written = results.Sum(r => r.RowsWritten);
+        var cols = new List<string> { "statement", "rows_written", "rows_read" };
+        var maps = results.Select((r, i) => new Dictionary<string, object?> { { "statement", i + 1 }, { "rows_written", r.RowsWritten }, { "rows_read", r.RowsRead } }).ToList();
+        ShowStatus($"batch() — {written} row(s) written, {results.Count} statements, no transaction", false);
+        ShowRows(cols, maps);
+    }
+
+    private async Task RunBatchInTransaction()
+    {
+        var results = await AppAmbitDb.BatchInTransaction(
+            DbStatement.Of("INSERT INTO tasks (title, is_completed, priority, due_date) VALUES (?, ?, ?, ?)", "Team meeting", 0, "high", "2026-06-06"),
+            DbStatement.Of("INSERT INTO tasks (title, is_completed, priority, due_date) VALUES (?, ?, ?, ?)", "Prepare agenda", 0, "medium", "2026-06-06"));
+        int written = results.Sum(r => r.RowsWritten);
+        var cols = new List<string> { "statement", "rows_written" };
+        var maps = results.Select((r, i) => new Dictionary<string, object?> { { "statement", i + 1 }, { "rows_written", r.RowsWritten } }).ToList();
+        ShowStatus($"batchInTransaction() — {written} row(s) written, rolled back on any failure", false);
+        ShowRows(cols, maps);
+    }
+
+    // ── Fluent SELECT ─────────────────────────────────────────────────────────
+
+    private async Task RunFluentSelect()
+    {
+        var maps = await AppAmbitDb.From("tasks")
+            .Select("id", "title", "priority", "due_date")
+            .Where("is_completed", "=", 0)
+            .OrderByDesc("due_date")
+            .Limit(5)
+            .Get();
+        ShowStatus(maps.Count == 0 ? "No pending tasks" : $"from().select().where().orderByDesc().limit(5) — {maps.Count} row(s)", false);
+        if (maps.Count > 0) ShowRows(maps[0].Keys.ToList(), maps);
+    }
+
+    private async Task RunWhereEquality()
+    {
+        var maps = await AppAmbitDb.From("tasks").Where("is_completed", 0).Get();
+        ShowStatus(maps.Count == 0 ? "No pending tasks" : $"where(is_completed, 0) — {maps.Count} row(s)", false);
+        ShowRows(maps.Count > 0 ? maps[0].Keys.ToList() : new List<string>(), maps);
+    }
+
+    private async Task RunWhereIn()
+    {
+        var maps = await AppAmbitDb.From("tasks")
+            .WhereIn("priority", new object?[] { "high", "medium" })
+            .OrderBy("due_date")
+            .Get();
+        ShowStatus(maps.Count == 0 ? "No high/medium tasks" : $"whereIn(priority, [high,medium]) — {maps.Count} row(s)", false);
+        ShowRows(maps.Count > 0 ? maps[0].Keys.ToList() : new List<string>(), maps);
+    }
+
+    private async Task RunOffset()
+    {
+        var maps = await AppAmbitDb.From("tasks").OrderBy("due_date").Limit(5).Offset(0).Get();
+        ShowStatus(maps.Count == 0 ? "No tasks" : $"limit(5).offset(0) — page 1, {maps.Count} row(s)", false);
+        ShowRows(maps.Count > 0 ? maps[0].Keys.ToList() : new List<string>(), maps);
+    }
+
+    private async Task RunFirst()
+    {
+        var item = await AppAmbitDb.From("tasks").Where("is_completed", "=", 0).OrderBy("due_date").First();
+        if (item == null) { ShowStatus("first() — no pending tasks", false); ShowRows(new List<string>(), new List<Dictionary<string, object?>>()); return; }
+        ShowStatus("first() — next task to expire", false);
+        ShowRows(item.Keys.ToList(), new List<Dictionary<string, object?>> { item });
+    }
+
+    private async Task RunCount()
+    {
+        var count = await AppAmbitDb.From("tasks").Where("is_completed", 0).Count();
+        var row = new Dictionary<string, object?> { { "pending_tasks", count } };
+        ShowStatus($"count() — {count} pending task(s)", false);
+        ShowRows(new List<string> { "pending_tasks" }, new List<Dictionary<string, object?>> { row });
+    }
+
+    // ── Mutations ─────────────────────────────────────────────────────────────
+
+    private async Task RunInsert()
+    {
+        var result = await AppAmbitDb.From("tasks").Insert(new Dictionary<string, object?>
+        {
+            { "title", "New task" }, { "is_completed", 0 },
+            { "priority", "medium" }, { "due_date", DateTime.UtcNow.AddDays(7).ToString("yyyy-MM-dd") }
+        });
+        ShowStatus($"insert() — rows_written={result.RowsWritten}", false);
+        ShowRows(new List<string> { "rows_written" }, new List<Dictionary<string, object?>> { new() { { "rows_written", result.RowsWritten } } });
+    }
+
+    private async Task RunUpdate()
+    {
+        var result = await AppAmbitDb.From("tasks")
+            .Where("title", "New task")
+            .Update(new Dictionary<string, object?> { { "is_completed", 1 } });
+        ShowStatus($"update() — rows_written={result.RowsWritten}  (run insert first)", false);
+        ShowRows(new List<string> { "rows_written" }, new List<Dictionary<string, object?>> { new() { { "rows_written", result.RowsWritten } } });
+    }
+
+    private async Task RunDelete()
+    {
+        var result = await AppAmbitDb.From("tasks").Where("is_completed", 1).Delete();
+        ShowStatus($"delete() — rows_written={result.RowsWritten}  (run update first)", false);
+        ShowRows(new List<string> { "rows_written" }, new List<Dictionary<string, object?>> { new() { { "rows_written", result.RowsWritten } } });
+    }
+
+    // ── Typed model ───────────────────────────────────────────────────────────
+
+    private async Task RunTypedModel()
+    {
+        var tasks = await AppAmbitDb.From<TaskModel>("tasks")
+            .Select("id", "title", "is_completed", "priority", "due_date")
+            .Limit(5)
+            .Get();
+        var cols = new List<string> { "id", "title", "isCompleted", "priority", "dueDate" };
+        var maps = tasks.Select(t => new Dictionary<string, object?> { { "id", t.Id }, { "title", t.Title }, { "isCompleted", t.IsCompleted }, { "priority", t.Priority }, { "dueDate", t.DueDate } }).ToList();
+        ShowStatus($"from<TaskModel>() — {tasks.Count} typed row(s)", false);
+        ShowRows(cols, maps);
+    }
+
+    // ── Presets ───────────────────────────────────────────────────────────────
+
+    private async Task RunPresetTables()
+    {
+        const string q = "SELECT name FROM sqlite_master WHERE type = 'table'";
+        Dispatcher.UIThread.Post(() => EditSql.Text = q);
+        var result = await AppAmbitDb.Execute(q);
+        if (result.HasError) { ShowStatus($"Error: {result.Error}", true); return; }
+        ShowStatus($"sqlite_master tables — {result.RowsRead} row(s)", false);
+        ShowRows(result.Columns, result.ToMaps());
+    }
+
+    private async Task RunPresetHighPriority()
+    {
+        const string q = "SELECT * FROM tasks WHERE priority = 'high'";
+        Dispatcher.UIThread.Post(() => EditSql.Text = q);
+        var result = await AppAmbitDb.Execute(q);
+        if (result.HasError) { ShowStatus($"Error: {result.Error}", true); return; }
+        ShowStatus($"tasks WHERE priority='high' — {result.RowsRead} row(s)", false);
+        ShowRows(result.Columns, result.ToMaps());
+    }
+}

--- a/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Views/MainView.axaml
+++ b/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Views/MainView.axaml
@@ -100,26 +100,36 @@
         <views:CmsView />
       </ScrollViewer>
 
+      <!-- Database view -->
+      <views:DatabaseView Name="DatabasePanel" IsVisible="False" />
+
     </Grid>
-    <Border Grid.Row="1" Background="Transparent" Padding="16">
-      <Border Name="BottomNav" Background="{StaticResource NavBackgroundBrush}" CornerRadius="28" Padding="8" HorizontalAlignment="Center" Width="420">
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="24">
-          <Button Classes="bottom-nav-item" Name="NavCrashes" Click="OnNavCrashesClicked">
-            <TextBlock Text="Crashes" FontSize="14" HorizontalAlignment="Center" VerticalAlignment="Center" />
-          </Button>
+    <Border Grid.Row="1" Background="Transparent" Padding="8,12">
+      <Border Name="BottomNav" Background="{StaticResource NavBackgroundBrush}" CornerRadius="28" Padding="6,6">
+        <ScrollViewer HorizontalScrollBarVisibility="Auto"
+                      VerticalScrollBarVisibility="Disabled">
+          <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="4">
+            <Button Classes="bottom-nav-item" Name="NavCrashes" Click="OnNavCrashesClicked">
+              <TextBlock Text="Crashes" FontSize="13" HorizontalAlignment="Center" VerticalAlignment="Center" />
+            </Button>
 
-          <Button Classes="bottom-nav-item" Name="NavAnalytics" Click="OnNavAnalyticsClicked">
-            <TextBlock Text="Analytics" FontSize="14" HorizontalAlignment="Center" VerticalAlignment="Center" />
-          </Button>
+            <Button Classes="bottom-nav-item" Name="NavAnalytics" Click="OnNavAnalyticsClicked">
+              <TextBlock Text="Analytics" FontSize="13" HorizontalAlignment="Center" VerticalAlignment="Center" />
+            </Button>
 
-          <Button Classes="bottom-nav-item" Name="NavRemoteConfig" Click="OnNavRemoteConfigClicked">
-            <TextBlock Text="Remote Config" FontSize="14" HorizontalAlignment="Center" VerticalAlignment="Center" />
-          </Button>
+            <Button Classes="bottom-nav-item" Name="NavRemoteConfig" Click="OnNavRemoteConfigClicked">
+              <TextBlock Text="Config" FontSize="13" HorizontalAlignment="Center" VerticalAlignment="Center" />
+            </Button>
 
-          <Button Classes="bottom-nav-item" Name="NavCms" Click="OnNavCmsClicked">
-            <TextBlock Text="CMS" FontSize="14" HorizontalAlignment="Center" VerticalAlignment="Center" />
-          </Button>
-        </StackPanel>
+            <Button Classes="bottom-nav-item" Name="NavCms" Click="OnNavCmsClicked">
+              <TextBlock Text="CMS" FontSize="13" HorizontalAlignment="Center" VerticalAlignment="Center" />
+            </Button>
+
+            <Button Classes="bottom-nav-item" Name="NavDatabase" Click="OnNavDatabaseClicked">
+              <TextBlock Text="DB" FontSize="13" HorizontalAlignment="Center" VerticalAlignment="Center" />
+            </Button>
+          </StackPanel>
+        </ScrollViewer>
       </Border>
     </Border>
   </Grid>

--- a/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Views/MainView.axaml.cs
+++ b/samples/AppAmbit.App.Avalonia/AppAmbit.App.Avalonia/Views/MainView.axaml.cs
@@ -72,6 +72,8 @@ public partial class MainView : UserControl
         CrashesPanel.IsVisible = true;
         AnalyticsPanel.IsVisible = false;
         RemoteConfigPanel.IsVisible = false;
+        CmsPanel.IsVisible = false;
+        DatabasePanel.IsVisible = false;
         UpdateNotificationButtonState();
     }
 
@@ -80,6 +82,8 @@ public partial class MainView : UserControl
         CrashesPanel.IsVisible = false;
         AnalyticsPanel.IsVisible = true;
         RemoteConfigPanel.IsVisible = false;
+        CmsPanel.IsVisible = false;
+        DatabasePanel.IsVisible = false;
     }
 
     private void OnNavRemoteConfigClicked(object? sender, RoutedEventArgs e)
@@ -88,6 +92,7 @@ public partial class MainView : UserControl
         AnalyticsPanel.IsVisible = false;
         RemoteConfigPanel.IsVisible = true;
         CmsPanel.IsVisible = false;
+        DatabasePanel.IsVisible = false;
 
         UpdateRemoteConfigUI();
     }
@@ -98,6 +103,16 @@ public partial class MainView : UserControl
         AnalyticsPanel.IsVisible = false;
         RemoteConfigPanel.IsVisible = false;
         CmsPanel.IsVisible = true;
+        DatabasePanel.IsVisible = false;
+    }
+
+    private void OnNavDatabaseClicked(object? sender, RoutedEventArgs e)
+    {
+        CrashesPanel.IsVisible = false;
+        AnalyticsPanel.IsVisible = false;
+        RemoteConfigPanel.IsVisible = false;
+        CmsPanel.IsVisible = false;
+        DatabasePanel.IsVisible = true;
     }
 
     private void UpdateRemoteConfigUI()

--- a/samples/AppAmbit.App.Maui.Native.Android/Adapters/DbRowAdapter.cs
+++ b/samples/AppAmbit.App.Maui.Native.Android/Adapters/DbRowAdapter.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using Android.Content;
+using Android.Graphics;
+using Android.Views;
+using Android.Widget;
+using AndroidX.RecyclerView.Widget;
+
+namespace AppAmbitTestingAppAndroid.Adapters;
+
+public class DbRowAdapter : RecyclerView.Adapter
+{
+    private List<string> _columns = new();
+    private List<Dictionary<string, object?>> _rows = new();
+
+    public override int ItemCount => _rows.Count;
+
+    public void UpdateData(List<string> columns, List<Dictionary<string, object?>> rows)
+    {
+        _columns = columns;
+        _rows = rows;
+        NotifyDataSetChanged();
+    }
+
+    public override void OnBindViewHolder(RecyclerView.ViewHolder holder, int position)
+    {
+        if (holder is DbRowViewHolder vh)
+            vh.Bind(_columns, _rows[position]);
+    }
+
+    public override RecyclerView.ViewHolder OnCreateViewHolder(ViewGroup parent, int viewType)
+    {
+        var ctx = parent.Context!;
+        int layoutId = ctx.Resources!.GetIdentifier("item_db_row", "layout", ctx.PackageName);
+        var view = LayoutInflater.From(ctx)!.Inflate(layoutId, parent, false);
+        return new DbRowViewHolder(view!);
+    }
+
+    private class DbRowViewHolder : RecyclerView.ViewHolder
+    {
+        private readonly LinearLayout _container;
+        private readonly Context _ctx;
+
+        public DbRowViewHolder(View itemView) : base(itemView)
+        {
+            _ctx = itemView.Context!;
+            int containerId = _ctx.Resources!.GetIdentifier("row_container", "id", _ctx.PackageName);
+            _container = itemView.FindViewById<LinearLayout>(containerId)!;
+        }
+
+        public void Bind(List<string> columns, Dictionary<string, object?> row)
+        {
+            _container.RemoveAllViews();
+
+            foreach (var col in columns)
+            {
+                var val = row.TryGetValue(col, out var v) ? v?.ToString() ?? "null" : "null";
+
+                var cell = new LinearLayout(_ctx)
+                {
+                    Orientation = Orientation.Vertical
+                };
+                cell.SetPadding(8, 4, 16, 4);
+
+                var header = new TextView(_ctx);
+                header.Text = col;
+                header.SetTextSize(Android.Util.ComplexUnitType.Sp, 10);
+                header.SetTextColor(Color.Gray);
+                header.SetTypeface(null, TypefaceStyle.Bold);
+
+                var value = new TextView(_ctx);
+                value.Text = val;
+                value.SetTextSize(Android.Util.ComplexUnitType.Sp, 13);
+                value.SetTextColor(Color.Black);
+                value.SetTypeface(Typeface.Monospace, TypefaceStyle.Normal);
+
+                cell.AddView(header);
+                cell.AddView(value);
+                _container.AddView(cell);
+            }
+        }
+    }
+}

--- a/samples/AppAmbit.App.Maui.Native.Android/MainActivity.cs
+++ b/samples/AppAmbit.App.Maui.Native.Android/MainActivity.cs
@@ -24,6 +24,7 @@ public class MainActivity : Activity
     View? _viewAnalytics;
     View? _viewRemoteConfig;
     View? _viewCms;
+    View? _viewDatabase;
     Button? _btnPushNotifications;
     bool _hasNotificationPermission;
     bool _notificationsEnabled;
@@ -73,20 +74,24 @@ public class MainActivity : Activity
         _viewAnalytics = inflater?.Inflate(L("fragment_analytics"), _container, false);
         _viewRemoteConfig = inflater?.Inflate(L("fragment_remote_config"), _container, false);
         _viewCms = inflater?.Inflate(L("fragment_cms"), _container, false);
+        _viewDatabase = inflater?.Inflate(L("fragment_database"), _container, false);
 
         WireCrashesView(_viewCrashes!);
         WireAnalyticsView(_viewAnalytics!);
         WireCmsView(_viewCms!);
+        WireDatabaseView(_viewDatabase!);
         
         var btnCrashes = FindViewById<Button>(I("btn_nav_crashes"))!;
         var btnAnalytics = FindViewById<Button>(I("btn_nav_analytics"))!;
         var btnRemoteConfig = FindViewById<Button>(I("btn_nav_remote_config"))!;
         var btnCms = FindViewById<Button>(I("btn_nav_cms"))!;
+        var btnDatabase = FindViewById<Button>(I("btn_nav_database"))!;
 
         btnCrashes.Click += (s, e) => ShowView(_viewCrashes!);
         btnAnalytics.Click += (s, e) => ShowView(_viewAnalytics!);
         btnRemoteConfig.Click += (s, e) => ShowRemoteConfigView(_viewRemoteConfig!);
         btnCms.Click += (s, e) => ShowView(_viewCms!);
+        btnDatabase.Click += (s, e) => ShowView(_viewDatabase!);
 
         ShowView(_viewCrashes!);
     }
@@ -402,6 +407,245 @@ public class MainActivity : Activity
     {
         ShowView(v);
         UpdateRemoteConfigUI(v);
+    }
+
+    void WireDatabaseView(View root)
+    {
+        T Find<T>(string id) where T : View => (T)root.FindViewById(I(id))!;
+
+        var editSql = Find<EditText>("edit_sql");
+        var spinner = Find<Spinner>("spin_db_functions");
+        var btnRun = Find<Button>("btn_db_run");
+        var txtStatus = Find<TextView>("txt_db_status");
+        var progress = Find<ProgressBar>("progress_db_loading");
+        var recycler = Find<AndroidX.RecyclerView.Widget.RecyclerView>("recycler_db_results");
+
+        var adapter = new DbRowAdapter();
+        recycler.SetLayoutManager(new AndroidX.RecyclerView.Widget.LinearLayoutManager(this));
+        recycler.SetAdapter(adapter);
+
+        var demos = new List<(string Label, Func<Task> Action)>
+        {
+            ("Raw SQL → execute(sql)",                          () => RunDbExecute(editSql, txtStatus, adapter)),
+            ("Raw SQL → execute(sql, params)",                  () => RunDbExecuteParams(txtStatus, adapter)),
+            ("Batch → batch()",                                 () => RunDbBatch(txtStatus, adapter)),
+            ("Batch → batchInTransaction()",                    () => RunDbBatchInTransaction(txtStatus, adapter)),
+            ("Fluent SELECT → select+where+orderByDesc+limit",  () => RunDbFluentSelect(txtStatus, adapter)),
+            ("Fluent SELECT → where(col,val)",                  () => RunDbWhereEquality(txtStatus, adapter)),
+            ("Fluent SELECT → whereIn()",                       () => RunDbWhereIn(txtStatus, adapter)),
+            ("Fluent SELECT → limit+offset",                    () => RunDbOffset(txtStatus, adapter)),
+            ("Fluent SELECT → first()",                         () => RunDbFirst(txtStatus, adapter)),
+            ("Fluent SELECT → count()",                         () => RunDbCount(txtStatus, adapter)),
+            ("Fluent WRITE → insert()",                         () => RunDbInsert(txtStatus, adapter)),
+            ("Fluent WRITE → update()",                         () => RunDbUpdate(txtStatus, adapter)),
+            ("Fluent WRITE → delete()",                         () => RunDbDelete(txtStatus, adapter)),
+            ("Typed Model → from(tasks, TaskModel.class)",      () => RunDbTypedModel(txtStatus, adapter)),
+            ("Preset → List tables",                            () => RunDbPresetTables(editSql, txtStatus, adapter)),
+            ("Preset → SELECT * WHERE priority='high'",         () => RunDbPresetHighPriority(editSql, txtStatus, adapter)),
+        };
+
+        var labels = demos.Select(d => d.Label).ToList();
+        var arrayAdapter = new ArrayAdapter<string>(this, Android.Resource.Layout.SimpleSpinnerItem, labels);
+        arrayAdapter.SetDropDownViewResource(Android.Resource.Layout.SimpleSpinnerDropDownItem);
+        spinner.Adapter = arrayAdapter;
+
+        btnRun.Click += async (s, e) =>
+        {
+            int pos = spinner.SelectedItemPosition;
+            if (pos < 0 || pos >= demos.Count) return;
+            var (label, action) = demos[pos];
+            SetDbStatus(txtStatus, $"Running: {label}", false);
+            RunOnUiThread(() => { btnRun.Enabled = false; progress.Visibility = Android.Views.ViewStates.Visible; });
+            try { await action(); }
+            catch (Exception ex) { SetDbStatus(txtStatus, $"Error: {ex.Message}", true); }
+            finally { RunOnUiThread(() => { btnRun.Enabled = true; progress.Visibility = Android.Views.ViewStates.Gone; }); }
+        };
+    }
+
+    void SetDbStatus(TextView tv, string message, bool isError)
+    {
+        RunOnUiThread(() =>
+        {
+            tv.Visibility = Android.Views.ViewStates.Visible;
+            tv.SetBackgroundColor(isError
+                ? Android.Graphics.Color.ParseColor("#FFEBEE")
+                : Android.Graphics.Color.ParseColor("#E8F5E9"));
+            tv.SetTextColor(isError
+                ? Android.Graphics.Color.ParseColor("#C62828")
+                : Android.Graphics.Color.ParseColor("#1B5E20"));
+            tv.Text = message;
+        });
+    }
+
+    void ShowDbRows(DbRowAdapter adapter, List<string> columns, List<Dictionary<string, object?>> rows)
+    {
+        RunOnUiThread(() => adapter.UpdateData(columns, rows));
+    }
+
+    // ── Raw Execute ───────────────────────────────────────────────────────────
+
+    async Task RunDbExecute(EditText editSql, TextView status, DbRowAdapter adapter)
+    {
+        var sql = editSql.Text?.Trim();
+        if (string.IsNullOrWhiteSpace(sql)) { sql = "SELECT * FROM tasks LIMIT 10"; RunOnUiThread(() => editSql.SetText(sql, TextView.BufferType.Normal)); }
+        var result = await AppAmbit.AppAmbitDb.Execute(sql);
+        if (result.HasError) { SetDbStatus(status, $"Error: {result.Error}", true); return; }
+        SetDbStatus(status, $"execute(sql) — rows_read={result.RowsRead}  rows_written={result.RowsWritten}", false);
+        ShowDbRows(adapter, result.Columns, result.ToMaps());
+    }
+
+    async Task RunDbExecuteParams(TextView status, DbRowAdapter adapter)
+    {
+        var result = await AppAmbit.AppAmbitDb.Execute("SELECT * FROM tasks WHERE is_completed = ? LIMIT ?", 0, 10);
+        if (result.HasError) { SetDbStatus(status, $"Error: {result.Error}", true); return; }
+        SetDbStatus(status, $"execute(sql, 0, 10) — rows_read={result.RowsRead}", false);
+        ShowDbRows(adapter, result.Columns, result.ToMaps());
+    }
+
+    // ── Batch ─────────────────────────────────────────────────────────────────
+
+    async Task RunDbBatch(TextView status, DbRowAdapter adapter)
+    {
+        var results = await AppAmbit.AppAmbitDb.Batch(
+            AppAmbit.Models.Db.DbStatement.Of("INSERT INTO tasks (title, is_completed, priority, due_date) VALUES (?, ?, ?, ?)", "Buy coffee", 0, "low", "2026-06-10"),
+            AppAmbit.Models.Db.DbStatement.Of("INSERT INTO tasks (title, is_completed, priority, due_date) VALUES (?, ?, ?, ?)", "Review PR", 0, "high", "2026-06-05"),
+            AppAmbit.Models.Db.DbStatement.Of("SELECT COUNT(*) AS total FROM tasks"));
+        int written = results.Sum(r => r.RowsWritten);
+        var cols = new List<string> { "statement", "rows_written", "rows_read" };
+        var maps = results.Select((r, i) => new Dictionary<string, object?> { { "statement", i + 1 }, { "rows_written", r.RowsWritten }, { "rows_read", r.RowsRead } }).ToList();
+        SetDbStatus(status, $"batch() — {written} row(s) written, {results.Count} statements, no transaction", false);
+        ShowDbRows(adapter, cols, maps);
+    }
+
+    async Task RunDbBatchInTransaction(TextView status, DbRowAdapter adapter)
+    {
+        var results = await AppAmbit.AppAmbitDb.BatchInTransaction(
+            AppAmbit.Models.Db.DbStatement.Of("INSERT INTO tasks (title, is_completed, priority, due_date) VALUES (?, ?, ?, ?)", "Team meeting", 0, "high", "2026-06-06"),
+            AppAmbit.Models.Db.DbStatement.Of("INSERT INTO tasks (title, is_completed, priority, due_date) VALUES (?, ?, ?, ?)", "Prepare agenda", 0, "medium", "2026-06-06"));
+        int written = results.Sum(r => r.RowsWritten);
+        var cols = new List<string> { "statement", "rows_written" };
+        var maps = results.Select((r, i) => new Dictionary<string, object?> { { "statement", i + 1 }, { "rows_written", r.RowsWritten } }).ToList();
+        SetDbStatus(status, $"batchInTransaction() — {written} row(s) written, rolled back on any failure", false);
+        ShowDbRows(adapter, cols, maps);
+    }
+
+    // ── Fluent SELECT ─────────────────────────────────────────────────────────
+
+    async Task RunDbFluentSelect(TextView status, DbRowAdapter adapter)
+    {
+        var maps = await AppAmbit.AppAmbitDb.From("tasks")
+            .Select("id", "title", "priority", "due_date")
+            .Where("is_completed", "=", 0)
+            .OrderByDesc("due_date")
+            .Limit(5)
+            .Get();
+        SetDbStatus(status, maps.Count == 0 ? "No pending tasks" : $"from().select().where().orderByDesc().limit(5) — {maps.Count} row(s)", false);
+        if (maps.Count > 0) ShowDbRows(adapter, maps[0].Keys.ToList(), maps);
+    }
+
+    async Task RunDbWhereEquality(TextView status, DbRowAdapter adapter)
+    {
+        var maps = await AppAmbit.AppAmbitDb.From("tasks").Where("is_completed", 0).Get();
+        SetDbStatus(status, maps.Count == 0 ? "No pending tasks" : $"where(is_completed, 0) — {maps.Count} row(s)", false);
+        ShowDbRows(adapter, maps.Count > 0 ? maps[0].Keys.ToList() : new List<string>(), maps);
+    }
+
+    async Task RunDbWhereIn(TextView status, DbRowAdapter adapter)
+    {
+        var maps = await AppAmbit.AppAmbitDb.From("tasks")
+            .WhereIn("priority", new object?[] { "high", "medium" })
+            .OrderBy("due_date")
+            .Get();
+        SetDbStatus(status, maps.Count == 0 ? "No high/medium tasks" : $"whereIn(priority, [high,medium]) — {maps.Count} row(s)", false);
+        ShowDbRows(adapter, maps.Count > 0 ? maps[0].Keys.ToList() : new List<string>(), maps);
+    }
+
+    async Task RunDbOffset(TextView status, DbRowAdapter adapter)
+    {
+        var maps = await AppAmbit.AppAmbitDb.From("tasks").OrderBy("due_date").Limit(5).Offset(0).Get();
+        SetDbStatus(status, maps.Count == 0 ? "No tasks" : $"limit(5).offset(0) — page 1, {maps.Count} row(s)", false);
+        ShowDbRows(adapter, maps.Count > 0 ? maps[0].Keys.ToList() : new List<string>(), maps);
+    }
+
+    async Task RunDbFirst(TextView status, DbRowAdapter adapter)
+    {
+        var item = await AppAmbit.AppAmbitDb.From("tasks").Where("is_completed", "=", 0).OrderBy("due_date").First();
+        if (item == null) { SetDbStatus(status, "first() — no pending tasks", false); ShowDbRows(adapter, new List<string>(), new List<Dictionary<string, object?>>()); return; }
+        SetDbStatus(status, "first() — next task to expire", false);
+        ShowDbRows(adapter, item.Keys.ToList(), new List<Dictionary<string, object?>> { item });
+    }
+
+    async Task RunDbCount(TextView status, DbRowAdapter adapter)
+    {
+        var count = await AppAmbit.AppAmbitDb.From("tasks").Where("is_completed", 0).Count();
+        var row = new Dictionary<string, object?> { { "pending_tasks", count } };
+        SetDbStatus(status, $"count() — {count} pending task(s)", false);
+        ShowDbRows(adapter, new List<string> { "pending_tasks" }, new List<Dictionary<string, object?>> { row });
+    }
+
+    // ── Mutations ─────────────────────────────────────────────────────────────
+
+    async Task RunDbInsert(TextView status, DbRowAdapter adapter)
+    {
+        var result = await AppAmbit.AppAmbitDb.From("tasks").Insert(new Dictionary<string, object?>
+        {
+            { "title", "New task" }, { "is_completed", 0 },
+            { "priority", "medium" }, { "due_date", DateTime.UtcNow.AddDays(7).ToString("yyyy-MM-dd") }
+        });
+        SetDbStatus(status, $"insert() — rows_written={result.RowsWritten}", false);
+        ShowDbRows(adapter, ["rows_written"], [new() { { "rows_written", result.RowsWritten } }]);
+    }
+
+    async Task RunDbUpdate(TextView status, DbRowAdapter adapter)
+    {
+        var result = await AppAmbit.AppAmbitDb.From("tasks")
+            .Where("title", "New task")
+            .Update(new Dictionary<string, object?> { { "is_completed", 1 } });
+        SetDbStatus(status, $"update() — rows_written={result.RowsWritten}  (run insert first)", false);
+        ShowDbRows(adapter, ["rows_written"], [new() { { "rows_written", result.RowsWritten } }]);
+    }
+
+    async Task RunDbDelete(TextView status, DbRowAdapter adapter)
+    {
+        var result = await AppAmbit.AppAmbitDb.From("tasks").Where("is_completed", 1).Delete();
+        SetDbStatus(status, $"delete() — rows_written={result.RowsWritten}  (run update first)", false);
+        ShowDbRows(adapter, ["rows_written"], [new() { { "rows_written", result.RowsWritten } }]);
+    }
+
+    // ── Typed model ───────────────────────────────────────────────────────────
+
+    async Task RunDbTypedModel(TextView status, DbRowAdapter adapter)
+    {
+        var tasks = await AppAmbit.AppAmbitDb.From<AppAmbitTestingAppAndroid.Models.TaskModel>("tasks")
+            .Select("id", "title", "is_completed", "priority", "due_date")
+            .Limit(5)
+            .Get();
+        var cols = new List<string> { "id", "title", "isCompleted", "priority", "dueDate" };
+        var maps = tasks.Select(t => new Dictionary<string, object?> { { "id", t.Id }, { "title", t.Title }, { "isCompleted", t.IsCompleted }, { "priority", t.Priority }, { "dueDate", t.DueDate } }).ToList();
+        SetDbStatus(status, $"from<TaskModel>() — {tasks.Count} typed row(s)", false);
+        ShowDbRows(adapter, cols, maps);
+    }
+
+    // ── Presets ───────────────────────────────────────────────────────────────
+
+    async Task RunDbPresetTables(EditText editSql, TextView status, DbRowAdapter adapter)
+    {
+        const string q = "SELECT name FROM sqlite_master WHERE type = 'table'";
+        RunOnUiThread(() => editSql.SetText(q, TextView.BufferType.Normal));
+        var result = await AppAmbit.AppAmbitDb.Execute(q);
+        if (result.HasError) { SetDbStatus(status, $"Error: {result.Error}", true); return; }
+        SetDbStatus(status, $"sqlite_master tables — {result.RowsRead} row(s)", false);
+        ShowDbRows(adapter, result.Columns, result.ToMaps());
+    }
+
+    async Task RunDbPresetHighPriority(EditText editSql, TextView status, DbRowAdapter adapter)
+    {
+        const string q = "SELECT * FROM tasks WHERE priority = 'high'";
+        RunOnUiThread(() => editSql.SetText(q, TextView.BufferType.Normal));
+        var result = await AppAmbit.AppAmbitDb.Execute(q);
+        if (result.HasError) { SetDbStatus(status, $"Error: {result.Error}", true); return; }
+        SetDbStatus(status, $"tasks WHERE priority='high' — {result.RowsRead} row(s)", false);
+        ShowDbRows(adapter, result.Columns, result.ToMaps());
     }
 
     void WireCmsView(View root)

--- a/samples/AppAmbit.App.Maui.Native.Android/Models/TaskModel.cs
+++ b/samples/AppAmbit.App.Maui.Native.Android/Models/TaskModel.cs
@@ -1,0 +1,12 @@
+using AppAmbit.Attributes;
+
+namespace AppAmbitTestingAppAndroid.Models;
+
+public class TaskModel
+{
+    public int Id { get; set; }
+    public string? Title { get; set; }
+    [DbColumn("is_completed")] public int IsCompleted { get; set; }
+    public string? Priority { get; set; }
+    [DbColumn("due_date")] public string? DueDate { get; set; }
+}

--- a/samples/AppAmbit.App.Maui.Native.Android/Resources/layout/activity_main.xml
+++ b/samples/AppAmbit.App.Maui.Native.Android/Resources/layout/activity_main.xml
@@ -17,7 +17,7 @@
         android:layout_width="match_parent"
         android:layout_height="56dp"
         android:orientation="horizontal"
-        android:weightSum="4"
+        android:weightSum="5"
         android:padding="8dp"
         android:elevation="8dp"
         android:background="@android:color/white">
@@ -53,5 +53,13 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:text="CMS" />
+
+        <Button
+            android:id="@+id/btn_nav_database"
+            style="@style/AppButton.Nav"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:text="DB" />
     </LinearLayout>
 </LinearLayout>

--- a/samples/AppAmbit.App.Maui.Native.Android/Resources/layout/fragment_database.xml
+++ b/samples/AppAmbit.App.Maui.Native.Android/Resources/layout/fragment_database.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="12dp"
+    android:background="@color/app_surface">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Database"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        android:textColor="@android:color/black"
+        android:gravity="center"
+        android:layout_marginBottom="10dp" />
+
+    <!-- SQL input -->
+    <EditText
+        android:id="@+id/edit_sql"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="SELECT * FROM tasks LIMIT 10"
+        android:text="SELECT * FROM tasks LIMIT 10"
+        android:fontFamily="monospace"
+        android:textSize="12sp"
+        android:minLines="2"
+        android:maxLines="4"
+        android:background="@drawable/bg_input"
+        android:padding="8dp"
+        android:layout_marginBottom="8dp" />
+
+    <!-- Spinner + Run button -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginBottom="6dp">
+
+        <Spinner
+            android:id="@+id/spin_db_functions"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_gravity="center_vertical" />
+
+        <Button
+            android:id="@+id/btn_db_run"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="▶ Run"
+            android:layout_marginStart="6dp" />
+    </LinearLayout>
+
+    <!-- Status bar -->
+    <TextView
+        android:id="@+id/txt_db_status"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="8dp"
+        android:textSize="12sp"
+        android:visibility="gone"
+        android:layout_marginBottom="6dp" />
+
+    <!-- Loading indicator -->
+    <ProgressBar
+        android:id="@+id/progress_db_loading"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:visibility="gone"
+        android:layout_marginBottom="4dp" />
+
+    <!-- Results RecyclerView -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_db_results"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:clipToPadding="false"
+        android:paddingBottom="8dp" />
+
+</LinearLayout>

--- a/samples/AppAmbit.App.Maui.Native.Android/Resources/layout/item_db_row.xml
+++ b/samples/AppAmbit.App.Maui.Native.Android/Resources/layout/item_db_row.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<HorizontalScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="2dp">
+
+    <LinearLayout
+        android:id="@+id/row_container"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="4dp"
+        android:background="@android:color/white" />
+
+</HorizontalScrollView>

--- a/samples/AppAmbit.App.Maui.Native.iOS/DatabaseViewController.cs
+++ b/samples/AppAmbit.App.Maui.Native.iOS/DatabaseViewController.cs
@@ -1,0 +1,500 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AppAmbit;
+using AppAmbit.Models.Db;
+using AppAmbitTestingiOS.Models;
+using CoreGraphics;
+using Foundation;
+using UIKit;
+
+namespace AppAmbitTestingiOS;
+
+public class DatabaseViewController : UIViewController
+{
+    private UITextView _editSql = null!;
+    private UIButton _btnFunction = null!;
+    private UIButton _btnRun = null!;
+    private UILabel _lblStatus = null!;
+    private UIActivityIndicatorView _spinner = null!;
+    private UITableView _tableView = null!;
+
+    private DbTableViewSource _source = null!;
+
+    private List<(string Label, Func<Task> Action)> _demos = new();
+    private int _selectedDemoIndex = 0;
+
+    public override void ViewDidLoad()
+    {
+        base.ViewDidLoad();
+        Title = "Database";
+        View!.BackgroundColor = UIColor.SystemBackground;
+
+        BuildDemos();
+        SetupUI();
+    }
+
+    private void BuildDemos()
+    {
+        _demos = new List<(string, Func<Task>)>
+        {
+            ("Raw SQL → execute(sql)",                         RunExecute),
+            ("Raw SQL → execute(sql, params)",                 RunExecuteParams),
+            ("Batch → batch()",                                RunBatch),
+            ("Batch → batchInTransaction()",                   RunBatchInTransaction),
+            ("Fluent SELECT → select+where+orderByDesc+limit", RunFluentSelect),
+            ("Fluent SELECT → where(col,val)",                 RunWhereEquality),
+            ("Fluent SELECT → whereIn()",                      RunWhereIn),
+            ("Fluent SELECT → limit+offset",                   RunOffset),
+            ("Fluent SELECT → first()",                        RunFirst),
+            ("Fluent SELECT → count()",                        RunCount),
+            ("Fluent WRITE → insert()",                        RunInsert),
+            ("Fluent WRITE → update()",                        RunUpdate),
+            ("Fluent WRITE → delete()",                        RunDelete),
+            ("Typed Model → from(tasks, TaskModel.class)",     RunTypedModel),
+            ("Preset → List tables",                           RunPresetTables),
+            ("Preset → SELECT * WHERE priority='high'",        RunPresetHighPriority),
+        };
+    }
+
+    private void SetupUI()
+    {
+        // SQL text view
+        _editSql = new UITextView
+        {
+            Text = "SELECT * FROM tasks LIMIT 10",
+            Font = UIFont.FromName("Courier", 13) ?? UIFont.SystemFontOfSize(13),
+            BackgroundColor = UIColor.SecondarySystemBackground,
+            TranslatesAutoresizingMaskIntoConstraints = false
+        };
+        _editSql.Layer.CornerRadius = 8;
+        _editSql.Layer.BorderColor = UIColor.SystemGray4.CGColor;
+        _editSql.Layer.BorderWidth = 1;
+        _editSql.TextContainerInset = new UIEdgeInsets(8, 8, 8, 8);
+
+        // Function picker button
+        _btnFunction = UIButton.FromType(UIButtonType.System);
+        _btnFunction.SetTitle(_demos[0].Label, UIControlState.Normal);
+        _btnFunction.HorizontalAlignment = UIControlContentHorizontalAlignment.Left;
+        _btnFunction.TranslatesAutoresizingMaskIntoConstraints = false;
+        _btnFunction.Layer.BorderColor = UIColor.SystemGray4.CGColor;
+        _btnFunction.Layer.BorderWidth = 1;
+        _btnFunction.Layer.CornerRadius = 8;
+        _btnFunction.ContentEdgeInsets = new UIEdgeInsets(0, 12, 0, 12);
+
+        if (OperatingSystem.IsIOSVersionAtLeast(14))
+        {
+            var actions = _demos.Select((d, idx) => UIAction.Create(d.Label, null, null, _ =>
+            {
+                _selectedDemoIndex = idx;
+                _btnFunction.SetTitle(d.Label, UIControlState.Normal);
+            })).ToArray();
+            _btnFunction.Menu = UIMenu.Create(string.Empty, actions);
+            _btnFunction.ShowsMenuAsPrimaryAction = true;
+        }
+
+        // Run button
+        _btnRun = UIButton.FromType(UIButtonType.System);
+        _btnRun.SetTitle("▶ Run", UIControlState.Normal);
+        _btnRun.BackgroundColor = UIColor.SystemBlue;
+        _btnRun.SetTitleColor(UIColor.White, UIControlState.Normal);
+        _btnRun.Layer.CornerRadius = 8;
+        _btnRun.TranslatesAutoresizingMaskIntoConstraints = false;
+        _btnRun.TouchUpInside += async (s, e) => await OnRun();
+
+        // Status label
+        _lblStatus = new UILabel
+        {
+            Text = "",
+            Font = UIFont.SystemFontOfSize(12),
+            Lines = 0,
+            Hidden = true,
+            TranslatesAutoresizingMaskIntoConstraints = false
+        };
+        _lblStatus.Layer.CornerRadius = 6;
+        _lblStatus.Layer.MasksToBounds = true;
+
+        _spinner = new UIActivityIndicatorView(UIActivityIndicatorViewStyle.Medium)
+        {
+            TranslatesAutoresizingMaskIntoConstraints = false,
+            HidesWhenStopped = true,
+            Color = UIColor.SystemBlue
+        };
+
+        // Table view
+        _tableView = new UITableView
+        {
+            TranslatesAutoresizingMaskIntoConstraints = false,
+            RowHeight = UITableView.AutomaticDimension,
+            EstimatedRowHeight = 44f,
+            SeparatorStyle = UITableViewCellSeparatorStyle.SingleLine
+        };
+        _tableView.RegisterClassForCellReuse(typeof(DbRowCell), DbRowCell.Key);
+        _source = new DbTableViewSource();
+        _tableView.Source = _source;
+
+        // Function row
+        var funcRow = new UIView { TranslatesAutoresizingMaskIntoConstraints = false };
+        funcRow.AddSubviews(_btnFunction, _btnRun);
+
+        View!.AddSubviews(_editSql, funcRow, _lblStatus, _spinner, _tableView);
+
+        var g = View.SafeAreaLayoutGuide;
+        NSLayoutConstraint.ActivateConstraints(new[]
+        {
+            _editSql.TopAnchor.ConstraintEqualTo(g.TopAnchor, 12),
+            _editSql.LeadingAnchor.ConstraintEqualTo(g.LeadingAnchor, 16),
+            _editSql.TrailingAnchor.ConstraintEqualTo(g.TrailingAnchor, -16),
+            _editSql.HeightAnchor.ConstraintEqualTo(70),
+
+            funcRow.TopAnchor.ConstraintEqualTo(_editSql.BottomAnchor, 10),
+            funcRow.LeadingAnchor.ConstraintEqualTo(g.LeadingAnchor, 16),
+            funcRow.TrailingAnchor.ConstraintEqualTo(g.TrailingAnchor, -16),
+            funcRow.HeightAnchor.ConstraintEqualTo(44),
+
+            _btnFunction.TopAnchor.ConstraintEqualTo(funcRow.TopAnchor),
+            _btnFunction.LeadingAnchor.ConstraintEqualTo(funcRow.LeadingAnchor),
+            _btnFunction.TrailingAnchor.ConstraintEqualTo(_btnRun.LeadingAnchor, -8),
+            _btnFunction.BottomAnchor.ConstraintEqualTo(funcRow.BottomAnchor),
+
+            _btnRun.TopAnchor.ConstraintEqualTo(funcRow.TopAnchor),
+            _btnRun.TrailingAnchor.ConstraintEqualTo(funcRow.TrailingAnchor),
+            _btnRun.WidthAnchor.ConstraintEqualTo(80),
+            _btnRun.BottomAnchor.ConstraintEqualTo(funcRow.BottomAnchor),
+
+            _lblStatus.TopAnchor.ConstraintEqualTo(funcRow.BottomAnchor, 8),
+            _lblStatus.LeadingAnchor.ConstraintEqualTo(g.LeadingAnchor, 16),
+            _lblStatus.TrailingAnchor.ConstraintEqualTo(g.TrailingAnchor, -16),
+
+            _spinner.TopAnchor.ConstraintEqualTo(_lblStatus.BottomAnchor, 8),
+            _spinner.CenterXAnchor.ConstraintEqualTo(g.CenterXAnchor),
+
+            _tableView.TopAnchor.ConstraintEqualTo(_spinner.BottomAnchor, 4),
+            _tableView.LeadingAnchor.ConstraintEqualTo(g.LeadingAnchor),
+            _tableView.TrailingAnchor.ConstraintEqualTo(g.TrailingAnchor),
+            _tableView.BottomAnchor.ConstraintEqualTo(g.BottomAnchor),
+        });
+    }
+
+    private async Task OnRun()
+    {
+        SetLoading(true);
+        var demo = _demos[_selectedDemoIndex];
+        ShowStatus($"Running: {demo.Label}", false);
+        try { await demo.Action(); }
+        catch (Exception ex) { ShowStatus($"Error: {ex.Message}", true); }
+        finally { SetLoading(false); }
+    }
+
+    private void SetLoading(bool loading)
+    {
+        InvokeOnMainThread(() =>
+        {
+            _btnRun.Enabled = !loading;
+            if (loading) _spinner.StartAnimating(); else _spinner.StopAnimating();
+        });
+    }
+
+    private void ShowStatus(string message, bool isError)
+    {
+        InvokeOnMainThread(() =>
+        {
+            _lblStatus.Hidden = false;
+            _lblStatus.Text = "  " + message + "  ";
+            _lblStatus.BackgroundColor = isError
+                ? UIColor.FromRGB(255, 235, 238)
+                : UIColor.FromRGB(232, 245, 233);
+            _lblStatus.TextColor = isError
+                ? UIColor.FromRGB(198, 40, 40)
+                : UIColor.FromRGB(27, 94, 32);
+        });
+    }
+
+    private void ShowRows(List<string> columns, List<Dictionary<string, object?>> rows)
+    {
+        InvokeOnMainThread(() =>
+        {
+            _source.UpdateData(columns, rows);
+            _tableView.ReloadData();
+        });
+    }
+
+    // ── Raw Execute ───────────────────────────────────────────────────────────
+
+    private async Task RunExecute()
+    {
+        var sql = _editSql.Text?.Trim();
+        if (string.IsNullOrWhiteSpace(sql))
+        {
+            sql = "SELECT * FROM tasks LIMIT 10";
+            InvokeOnMainThread(() => _editSql.Text = sql);
+        }
+        var result = await AppAmbitDb.Execute(sql);
+        if (result.HasError) { ShowStatus($"Error: {result.Error}", true); return; }
+        ShowStatus($"execute(sql) — rows_read={result.RowsRead}  rows_written={result.RowsWritten}", false);
+        ShowRows(result.Columns, result.ToMaps());
+    }
+
+    private async Task RunExecuteParams()
+    {
+        var result = await AppAmbitDb.Execute("SELECT * FROM tasks WHERE is_completed = ? LIMIT ?", 0, 10);
+        if (result.HasError) { ShowStatus($"Error: {result.Error}", true); return; }
+        ShowStatus($"execute(sql, 0, 10) — rows_read={result.RowsRead}", false);
+        ShowRows(result.Columns, result.ToMaps());
+    }
+
+    // ── Batch ─────────────────────────────────────────────────────────────────
+
+    private async Task RunBatch()
+    {
+        var results = await AppAmbitDb.Batch(
+            DbStatement.Of("INSERT INTO tasks (title, is_completed, priority, due_date) VALUES (?, ?, ?, ?)", "Buy coffee", 0, "low", "2026-06-10"),
+            DbStatement.Of("INSERT INTO tasks (title, is_completed, priority, due_date) VALUES (?, ?, ?, ?)", "Review PR", 0, "high", "2026-06-05"),
+            DbStatement.Of("SELECT COUNT(*) AS total FROM tasks"));
+        int written = results.Sum(r => r.RowsWritten);
+        var cols = new List<string> { "statement", "rows_written", "rows_read" };
+        var maps = results.Select((r, i) => new Dictionary<string, object?> { { "statement", i + 1 }, { "rows_written", r.RowsWritten }, { "rows_read", r.RowsRead } }).ToList();
+        ShowStatus($"batch() — {written} row(s) written, {results.Count} statements, no transaction", false);
+        ShowRows(cols, maps);
+    }
+
+    private async Task RunBatchInTransaction()
+    {
+        var results = await AppAmbitDb.BatchInTransaction(
+            DbStatement.Of("INSERT INTO tasks (title, is_completed, priority, due_date) VALUES (?, ?, ?, ?)", "Team meeting", 0, "high", "2026-06-06"),
+            DbStatement.Of("INSERT INTO tasks (title, is_completed, priority, due_date) VALUES (?, ?, ?, ?)", "Prepare agenda", 0, "medium", "2026-06-06"));
+        int written = results.Sum(r => r.RowsWritten);
+        var cols = new List<string> { "statement", "rows_written" };
+        var maps = results.Select((r, i) => new Dictionary<string, object?> { { "statement", i + 1 }, { "rows_written", r.RowsWritten } }).ToList();
+        ShowStatus($"batchInTransaction() — {written} row(s) written, rolled back on any failure", false);
+        ShowRows(cols, maps);
+    }
+
+    // ── Fluent SELECT ─────────────────────────────────────────────────────────
+
+    private async Task RunFluentSelect()
+    {
+        var maps = await AppAmbitDb.From("tasks")
+            .Select("id", "title", "priority", "due_date")
+            .Where("is_completed", "=", 0)
+            .OrderByDesc("due_date")
+            .Limit(5)
+            .Get();
+        ShowStatus(maps.Count == 0 ? "No pending tasks" : $"from().select().where().orderByDesc().limit(5) — {maps.Count} row(s)", false);
+        if (maps.Count > 0) ShowRows(maps[0].Keys.ToList(), maps);
+    }
+
+    private async Task RunWhereEquality()
+    {
+        var maps = await AppAmbitDb.From("tasks").Where("is_completed", 0).Get();
+        ShowStatus(maps.Count == 0 ? "No pending tasks" : $"where(is_completed, 0) — {maps.Count} row(s)", false);
+        ShowRows(maps.Count > 0 ? maps[0].Keys.ToList() : new List<string>(), maps);
+    }
+
+    private async Task RunWhereIn()
+    {
+        var maps = await AppAmbitDb.From("tasks")
+            .WhereIn("priority", new object?[] { "high", "medium" })
+            .OrderBy("due_date")
+            .Get();
+        ShowStatus(maps.Count == 0 ? "No high/medium tasks" : $"whereIn(priority, [high,medium]) — {maps.Count} row(s)", false);
+        ShowRows(maps.Count > 0 ? maps[0].Keys.ToList() : new List<string>(), maps);
+    }
+
+    private async Task RunOffset()
+    {
+        var maps = await AppAmbitDb.From("tasks").OrderBy("due_date").Limit(5).Offset(0).Get();
+        ShowStatus(maps.Count == 0 ? "No tasks" : $"limit(5).offset(0) — page 1, {maps.Count} row(s)", false);
+        ShowRows(maps.Count > 0 ? maps[0].Keys.ToList() : new List<string>(), maps);
+    }
+
+    private async Task RunFirst()
+    {
+        var item = await AppAmbitDb.From("tasks").Where("is_completed", "=", 0).OrderBy("due_date").First();
+        if (item == null) { ShowStatus("first() — no pending tasks", false); ShowRows(new List<string>(), new List<Dictionary<string, object?>>()); return; }
+        ShowStatus("first() — next task to expire", false);
+        ShowRows(item.Keys.ToList(), new List<Dictionary<string, object?>> { item });
+    }
+
+    private async Task RunCount()
+    {
+        var count = await AppAmbitDb.From("tasks").Where("is_completed", 0).Count();
+        var row = new Dictionary<string, object?> { { "pending_tasks", count } };
+        ShowStatus($"count() — {count} pending task(s)", false);
+        ShowRows(new List<string> { "pending_tasks" }, new List<Dictionary<string, object?>> { row });
+    }
+
+    // ── Mutations ─────────────────────────────────────────────────────────────
+
+    private async Task RunInsert()
+    {
+        var result = await AppAmbitDb.From("tasks").Insert(new Dictionary<string, object?>
+        {
+            { "title", "New task" }, { "is_completed", 0 },
+            { "priority", "medium" }, { "due_date", DateTime.UtcNow.AddDays(7).ToString("yyyy-MM-dd") }
+        });
+        ShowStatus($"insert() — rows_written={result.RowsWritten}", false);
+        ShowRows(new List<string> { "rows_written" }, new List<Dictionary<string, object?>> { new() { { "rows_written", result.RowsWritten } } });
+    }
+
+    private async Task RunUpdate()
+    {
+        var result = await AppAmbitDb.From("tasks")
+            .Where("title", "New task")
+            .Update(new Dictionary<string, object?> { { "is_completed", 1 } });
+        ShowStatus($"update() — rows_written={result.RowsWritten}  (run insert first)", false);
+        ShowRows(new List<string> { "rows_written" }, new List<Dictionary<string, object?>> { new() { { "rows_written", result.RowsWritten } } });
+    }
+
+    private async Task RunDelete()
+    {
+        var result = await AppAmbitDb.From("tasks").Where("is_completed", 1).Delete();
+        ShowStatus($"delete() — rows_written={result.RowsWritten}  (run update first)", false);
+        ShowRows(new List<string> { "rows_written" }, new List<Dictionary<string, object?>> { new() { { "rows_written", result.RowsWritten } } });
+    }
+
+    // ── Typed model ───────────────────────────────────────────────────────────
+
+    private async Task RunTypedModel()
+    {
+        var tasks = await AppAmbitDb.From<TaskModel>("tasks")
+            .Select("id", "title", "is_completed", "priority", "due_date")
+            .Limit(5)
+            .Get();
+        var cols = new List<string> { "id", "title", "isCompleted", "priority", "dueDate" };
+        var maps = tasks.Select(t => new Dictionary<string, object?> { { "id", t.Id }, { "title", t.Title }, { "isCompleted", t.IsCompleted }, { "priority", t.Priority }, { "dueDate", t.DueDate } }).ToList();
+        ShowStatus($"from<TaskModel>() — {tasks.Count} typed row(s)", false);
+        ShowRows(cols, maps);
+    }
+
+    // ── Presets ───────────────────────────────────────────────────────────────
+
+    private async Task RunPresetTables()
+    {
+        const string q = "SELECT name FROM sqlite_master WHERE type = 'table'";
+        InvokeOnMainThread(() => _editSql.Text = q);
+        var result = await AppAmbitDb.Execute(q);
+        if (result.HasError) { ShowStatus($"Error: {result.Error}", true); return; }
+        ShowStatus($"sqlite_master tables — {result.RowsRead} row(s)", false);
+        ShowRows(result.Columns, result.ToMaps());
+    }
+
+    private async Task RunPresetHighPriority()
+    {
+        const string q = "SELECT * FROM tasks WHERE priority = 'high'";
+        InvokeOnMainThread(() => _editSql.Text = q);
+        var result = await AppAmbitDb.Execute(q);
+        if (result.HasError) { ShowStatus($"Error: {result.Error}", true); return; }
+        ShowStatus($"tasks WHERE priority='high' — {result.RowsRead} row(s)", false);
+        ShowRows(result.Columns, result.ToMaps());
+    }
+}
+
+// ── Table view data source ────────────────────────────────────────────────────
+
+public class DbTableViewSource : UITableViewSource
+{
+    private List<string> _columns = new();
+    private List<Dictionary<string, object?>> _rows = new();
+
+    public void UpdateData(List<string> columns, List<Dictionary<string, object?>> rows)
+    {
+        _columns = columns;
+        _rows = rows;
+    }
+
+    public override nint RowsInSection(UITableView tableview, nint section) => _rows.Count;
+
+    public override UITableViewCell GetCell(UITableView tableView, NSIndexPath indexPath)
+    {
+        var cell = (DbRowCell)tableView.DequeueReusableCell(DbRowCell.Key, indexPath);
+        cell.Bind(_columns, _rows[indexPath.Row]);
+        return cell;
+    }
+}
+
+// ── Table view cell ───────────────────────────────────────────────────────────
+
+public class DbRowCell : UITableViewCell
+{
+    public static readonly NSString Key = new NSString(nameof(DbRowCell));
+
+    private UIScrollView _scroll = null!;
+    private UIStackView _stack = null!;
+
+    [Export("initWithStyle:reuseIdentifier:")]
+    public DbRowCell(UITableViewCellStyle style, NSString reuseIdentifier) : base(style, reuseIdentifier)
+    {
+        SelectionStyle = UITableViewCellSelectionStyle.None;
+
+        _scroll = new UIScrollView
+        {
+            TranslatesAutoresizingMaskIntoConstraints = false,
+            ShowsVerticalScrollIndicator = false
+        };
+
+        _stack = new UIStackView
+        {
+            Axis = UILayoutConstraintAxis.Horizontal,
+            Spacing = 16,
+            Alignment = UIStackViewAlignment.Top,
+            Distribution = UIStackViewDistribution.EqualSpacing,
+            TranslatesAutoresizingMaskIntoConstraints = false
+        };
+
+        _scroll.AddSubview(_stack);
+        ContentView.AddSubview(_scroll);
+
+        NSLayoutConstraint.ActivateConstraints(new[]
+        {
+            _scroll.TopAnchor.ConstraintEqualTo(ContentView.TopAnchor, 4),
+            _scroll.LeadingAnchor.ConstraintEqualTo(ContentView.LeadingAnchor, 8),
+            _scroll.TrailingAnchor.ConstraintEqualTo(ContentView.TrailingAnchor, -8),
+            _scroll.BottomAnchor.ConstraintEqualTo(ContentView.BottomAnchor, -4),
+            _scroll.HeightAnchor.ConstraintEqualTo(52),
+
+            _stack.TopAnchor.ConstraintEqualTo(_scroll.TopAnchor),
+            _stack.LeadingAnchor.ConstraintEqualTo(_scroll.LeadingAnchor),
+            _stack.BottomAnchor.ConstraintEqualTo(_scroll.BottomAnchor),
+            _stack.HeightAnchor.ConstraintEqualTo(_scroll.HeightAnchor),
+        });
+    }
+
+    public void Bind(List<string> columns, Dictionary<string, object?> row)
+    {
+        foreach (var sub in _stack.ArrangedSubviews) sub.RemoveFromSuperview();
+
+        foreach (var col in columns)
+        {
+            var val = row.TryGetValue(col, out var v) ? v?.ToString() ?? "null" : "null";
+
+            var colView = new UIStackView
+            {
+                Axis = UILayoutConstraintAxis.Vertical,
+                Spacing = 2,
+                TranslatesAutoresizingMaskIntoConstraints = false
+            };
+
+            var header = new UILabel
+            {
+                Text = col,
+                Font = UIFont.BoldSystemFontOfSize(10),
+                TextColor = UIColor.SystemGray,
+                TranslatesAutoresizingMaskIntoConstraints = false
+            };
+
+            var value = new UILabel
+            {
+                Text = val,
+                Font = UIFont.FromName("Courier", 13) ?? UIFont.SystemFontOfSize(13),
+                TextColor = UIColor.Label,
+                TranslatesAutoresizingMaskIntoConstraints = false
+            };
+
+            colView.AddArrangedSubview(header);
+            colView.AddArrangedSubview(value);
+            _stack.AddArrangedSubview(colView);
+        }
+    }
+}

--- a/samples/AppAmbit.App.Maui.Native.iOS/MainTabBarController.cs
+++ b/samples/AppAmbit.App.Maui.Native.iOS/MainTabBarController.cs
@@ -48,6 +48,13 @@ public class MainTabBarController : UITabBarController
              ? new UITabBarItem("CMS", imgCms, 3)
              : new UITabBarItem("CMS", null, 3);
 
-        ViewControllers = new UIViewController[] { crashesNav, analyticsNav, configNav, cmsNav };
+        var database = new DatabaseViewController();
+        var databaseNav = new UINavigationController(database);
+        var imgDb = SysImg("externaldrive");
+        databaseNav.TabBarItem = imgDb != null
+             ? new UITabBarItem("DB", imgDb, 4)
+             : new UITabBarItem("DB", null, 4);
+
+        ViewControllers = new UIViewController[] { crashesNav, analyticsNav, configNav, cmsNav, databaseNav };
     }
 }

--- a/samples/AppAmbit.App.Maui.Native.iOS/Models/TaskModel.cs
+++ b/samples/AppAmbit.App.Maui.Native.iOS/Models/TaskModel.cs
@@ -1,0 +1,12 @@
+using AppAmbit.Attributes;
+
+namespace AppAmbitTestingiOS.Models;
+
+public class TaskModel
+{
+    public int Id { get; set; }
+    public string? Title { get; set; }
+    [DbColumn("is_completed")] public int IsCompleted { get; set; }
+    public string? Priority { get; set; }
+    [DbColumn("due_date")] public string? DueDate { get; set; }
+}

--- a/samples/AppAmbit.App.Maui.Native.macOS/DatabaseViewController.cs
+++ b/samples/AppAmbit.App.Maui.Native.macOS/DatabaseViewController.cs
@@ -1,0 +1,444 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AppAmbit;
+using AppAmbit.Attributes;
+using AppAmbit.Models.Db;
+using Foundation;
+using UIKit;
+
+namespace AppAmbitTestingMacOs;
+
+public class DatabaseViewController : UIViewController
+{
+    private UITextView _editSql = null!;
+    private UIButton _btnFunction = null!;
+    private UIButton _btnRun = null!;
+    private UILabel _lblStatus = null!;
+    private UIActivityIndicatorView _spinner = null!;
+    private UITableView _tableView = null!;
+
+    private DbMacTableViewSource _source = null!;
+
+    private List<(string Label, Func<Task> Action)> _demos = new();
+    private int _selectedDemoIndex = 0;
+
+    public override void ViewDidLoad()
+    {
+        base.ViewDidLoad();
+        Title = "Database";
+        View!.BackgroundColor = UIColor.SystemBackground;
+        BuildDemos();
+        SetupUI();
+    }
+
+    private void BuildDemos()
+    {
+        _demos = new List<(string, Func<Task>)>
+        {
+            ("Raw SQL → execute(sql)",                         RunExecute),
+            ("Raw SQL → execute(sql, params)",                 RunExecuteParams),
+            ("Batch → batch()",                                RunBatch),
+            ("Batch → batchInTransaction()",                   RunBatchInTransaction),
+            ("Fluent SELECT → select+where+orderByDesc+limit", RunFluentSelect),
+            ("Fluent SELECT → where(col,val)",                 RunWhereEquality),
+            ("Fluent SELECT → whereIn()",                      RunWhereIn),
+            ("Fluent SELECT → limit+offset",                   RunOffset),
+            ("Fluent SELECT → first()",                        RunFirst),
+            ("Fluent SELECT → count()",                        RunCount),
+            ("Fluent WRITE → insert()",                        RunInsert),
+            ("Fluent WRITE → update()",                        RunUpdate),
+            ("Fluent WRITE → delete()",                        RunDelete),
+            ("Typed Model → from(tasks, TaskModel.class)",     RunTypedModel),
+            ("Preset → List tables",                           RunPresetTables),
+            ("Preset → SELECT * WHERE priority='high'",        RunPresetHighPriority),
+        };
+    }
+
+    private void SetupUI()
+    {
+        _editSql = new UITextView
+        {
+            Text = "SELECT * FROM tasks LIMIT 10",
+            Font = UIFont.FromName("Courier", 13) ?? UIFont.SystemFontOfSize(13),
+            BackgroundColor = UIColor.SecondarySystemBackground,
+            TranslatesAutoresizingMaskIntoConstraints = false
+        };
+        _editSql.Layer.CornerRadius = 8;
+        _editSql.Layer.BorderColor = UIColor.SystemGray4.CGColor;
+        _editSql.Layer.BorderWidth = 1;
+        _editSql.TextContainerInset = new UIEdgeInsets(8, 8, 8, 8);
+
+        _btnFunction = UIButton.FromType(UIButtonType.System);
+        _btnFunction.SetTitle(_demos[0].Label, UIControlState.Normal);
+        _btnFunction.HorizontalAlignment = UIControlContentHorizontalAlignment.Left;
+        _btnFunction.TranslatesAutoresizingMaskIntoConstraints = false;
+        _btnFunction.Layer.BorderColor = UIColor.SystemGray4.CGColor;
+        _btnFunction.Layer.BorderWidth = 1;
+        _btnFunction.Layer.CornerRadius = 8;
+        _btnFunction.ContentEdgeInsets = new UIEdgeInsets(0, 12, 0, 12);
+
+        if (OperatingSystem.IsIOSVersionAtLeast(14))
+        {
+            var actions = _demos.Select((d, idx) => UIAction.Create(d.Label, null, null, _ =>
+            {
+                _selectedDemoIndex = idx;
+                _btnFunction.SetTitle(d.Label, UIControlState.Normal);
+            })).ToArray();
+            _btnFunction.Menu = UIMenu.Create(string.Empty, actions);
+            _btnFunction.ShowsMenuAsPrimaryAction = true;
+        }
+
+        _btnRun = UIButton.FromType(UIButtonType.System);
+        _btnRun.SetTitle("▶ Run", UIControlState.Normal);
+        _btnRun.BackgroundColor = UIColor.SystemBlue;
+        _btnRun.SetTitleColor(UIColor.White, UIControlState.Normal);
+        _btnRun.Layer.CornerRadius = 8;
+        _btnRun.TranslatesAutoresizingMaskIntoConstraints = false;
+        _btnRun.TouchUpInside += async (s, e) => await OnRun();
+
+        _lblStatus = new UILabel
+        {
+            Text = "",
+            Font = UIFont.SystemFontOfSize(12),
+            Lines = 0,
+            Hidden = true,
+            TranslatesAutoresizingMaskIntoConstraints = false
+        };
+        _lblStatus.Layer.CornerRadius = 6;
+        _lblStatus.Layer.MasksToBounds = true;
+
+        _spinner = new UIActivityIndicatorView(UIActivityIndicatorViewStyle.Medium)
+        {
+            TranslatesAutoresizingMaskIntoConstraints = false,
+            HidesWhenStopped = true,
+            Color = UIColor.SystemBlue
+        };
+
+        _tableView = new UITableView
+        {
+            TranslatesAutoresizingMaskIntoConstraints = false,
+            RowHeight = UITableView.AutomaticDimension,
+            EstimatedRowHeight = 44f,
+            SeparatorStyle = UITableViewCellSeparatorStyle.SingleLine
+        };
+        _tableView.RegisterClassForCellReuse(typeof(DbMacRowCell), DbMacRowCell.Key);
+        _source = new DbMacTableViewSource();
+        _tableView.Source = _source;
+
+        var funcRow = new UIView { TranslatesAutoresizingMaskIntoConstraints = false };
+        funcRow.AddSubviews(_btnFunction, _btnRun);
+
+        View!.AddSubviews(_editSql, funcRow, _lblStatus, _spinner, _tableView);
+
+        var g = View.SafeAreaLayoutGuide;
+        NSLayoutConstraint.ActivateConstraints(new[]
+        {
+            _editSql.TopAnchor.ConstraintEqualTo(g.TopAnchor, 12),
+            _editSql.LeadingAnchor.ConstraintEqualTo(g.LeadingAnchor, 16),
+            _editSql.TrailingAnchor.ConstraintEqualTo(g.TrailingAnchor, -16),
+            _editSql.HeightAnchor.ConstraintEqualTo(70),
+
+            funcRow.TopAnchor.ConstraintEqualTo(_editSql.BottomAnchor, 10),
+            funcRow.LeadingAnchor.ConstraintEqualTo(g.LeadingAnchor, 16),
+            funcRow.TrailingAnchor.ConstraintEqualTo(g.TrailingAnchor, -16),
+            funcRow.HeightAnchor.ConstraintEqualTo(44),
+
+            _btnFunction.TopAnchor.ConstraintEqualTo(funcRow.TopAnchor),
+            _btnFunction.LeadingAnchor.ConstraintEqualTo(funcRow.LeadingAnchor),
+            _btnFunction.TrailingAnchor.ConstraintEqualTo(_btnRun.LeadingAnchor, -8),
+            _btnFunction.BottomAnchor.ConstraintEqualTo(funcRow.BottomAnchor),
+
+            _btnRun.TopAnchor.ConstraintEqualTo(funcRow.TopAnchor),
+            _btnRun.TrailingAnchor.ConstraintEqualTo(funcRow.TrailingAnchor),
+            _btnRun.WidthAnchor.ConstraintEqualTo(80),
+            _btnRun.BottomAnchor.ConstraintEqualTo(funcRow.BottomAnchor),
+
+            _lblStatus.TopAnchor.ConstraintEqualTo(funcRow.BottomAnchor, 8),
+            _lblStatus.LeadingAnchor.ConstraintEqualTo(g.LeadingAnchor, 16),
+            _lblStatus.TrailingAnchor.ConstraintEqualTo(g.TrailingAnchor, -16),
+
+            _spinner.TopAnchor.ConstraintEqualTo(_lblStatus.BottomAnchor, 8),
+            _spinner.CenterXAnchor.ConstraintEqualTo(g.CenterXAnchor),
+
+            _tableView.TopAnchor.ConstraintEqualTo(_spinner.BottomAnchor, 4),
+            _tableView.LeadingAnchor.ConstraintEqualTo(g.LeadingAnchor),
+            _tableView.TrailingAnchor.ConstraintEqualTo(g.TrailingAnchor),
+            _tableView.BottomAnchor.ConstraintEqualTo(g.BottomAnchor),
+        });
+    }
+
+    private async Task OnRun()
+    {
+        SetLoading(true);
+        var demo = _demos[_selectedDemoIndex];
+        ShowStatus($"Running: {demo.Label}", false);
+        try { await demo.Action(); }
+        catch (Exception ex) { ShowStatus($"Error: {ex.Message}", true); }
+        finally { SetLoading(false); }
+    }
+
+    private void SetLoading(bool loading)
+    {
+        InvokeOnMainThread(() =>
+        {
+            _btnRun.Enabled = !loading;
+            if (loading) _spinner.StartAnimating(); else _spinner.StopAnimating();
+        });
+    }
+
+    private void ShowStatus(string message, bool isError)
+    {
+        InvokeOnMainThread(() =>
+        {
+            _lblStatus.Hidden = false;
+            _lblStatus.Text = "  " + message + "  ";
+            _lblStatus.BackgroundColor = isError ? UIColor.FromRGB(255, 235, 238) : UIColor.FromRGB(232, 245, 233);
+            _lblStatus.TextColor = isError ? UIColor.FromRGB(198, 40, 40) : UIColor.FromRGB(27, 94, 32);
+        });
+    }
+
+    private void ShowRows(List<string> columns, List<Dictionary<string, object?>> rows)
+    {
+        InvokeOnMainThread(() => { _source.UpdateData(columns, rows); _tableView.ReloadData(); });
+    }
+
+    // ── Raw Execute ───────────────────────────────────────────────────────────
+
+    private async Task RunExecute()
+    {
+        var sql = _editSql.Text?.Trim();
+        if (string.IsNullOrWhiteSpace(sql)) { sql = "SELECT * FROM tasks LIMIT 10"; InvokeOnMainThread(() => _editSql.Text = sql); }
+        var result = await AppAmbitDb.Execute(sql);
+        if (result.HasError) { ShowStatus($"Error: {result.Error}", true); return; }
+        ShowStatus($"execute(sql) — rows_read={result.RowsRead}  rows_written={result.RowsWritten}", false);
+        ShowRows(result.Columns, result.ToMaps());
+    }
+
+    private async Task RunExecuteParams()
+    {
+        var result = await AppAmbitDb.Execute("SELECT * FROM tasks WHERE is_completed = ? LIMIT ?", 0, 10);
+        if (result.HasError) { ShowStatus($"Error: {result.Error}", true); return; }
+        ShowStatus($"execute(sql, 0, 10) — rows_read={result.RowsRead}", false);
+        ShowRows(result.Columns, result.ToMaps());
+    }
+
+    // ── Batch ─────────────────────────────────────────────────────────────────
+
+    private async Task RunBatch()
+    {
+        var results = await AppAmbitDb.Batch(
+            DbStatement.Of("INSERT INTO tasks (title, is_completed, priority, due_date) VALUES (?, ?, ?, ?)", "Buy coffee", 0, "low", "2026-06-10"),
+            DbStatement.Of("INSERT INTO tasks (title, is_completed, priority, due_date) VALUES (?, ?, ?, ?)", "Review PR", 0, "high", "2026-06-05"),
+            DbStatement.Of("SELECT COUNT(*) AS total FROM tasks"));
+        int written = results.Sum(r => r.RowsWritten);
+        var cols = new List<string> { "statement", "rows_written", "rows_read" };
+        var maps = results.Select((r, i) => new Dictionary<string, object?> { { "statement", i + 1 }, { "rows_written", r.RowsWritten }, { "rows_read", r.RowsRead } }).ToList();
+        ShowStatus($"batch() — {written} row(s) written, {results.Count} statements, no transaction", false);
+        ShowRows(cols, maps);
+    }
+
+    private async Task RunBatchInTransaction()
+    {
+        var results = await AppAmbitDb.BatchInTransaction(
+            DbStatement.Of("INSERT INTO tasks (title, is_completed, priority, due_date) VALUES (?, ?, ?, ?)", "Team meeting", 0, "high", "2026-06-06"),
+            DbStatement.Of("INSERT INTO tasks (title, is_completed, priority, due_date) VALUES (?, ?, ?, ?)", "Prepare agenda", 0, "medium", "2026-06-06"));
+        int written = results.Sum(r => r.RowsWritten);
+        var cols = new List<string> { "statement", "rows_written" };
+        var maps = results.Select((r, i) => new Dictionary<string, object?> { { "statement", i + 1 }, { "rows_written", r.RowsWritten } }).ToList();
+        ShowStatus($"batchInTransaction() — {written} row(s) written, rolled back on any failure", false);
+        ShowRows(cols, maps);
+    }
+
+    // ── Fluent SELECT ─────────────────────────────────────────────────────────
+
+    private async Task RunFluentSelect()
+    {
+        var maps = await AppAmbitDb.From("tasks").Select("id", "title", "priority", "due_date").Where("is_completed", "=", 0).OrderByDesc("due_date").Limit(5).Get();
+        ShowStatus(maps.Count == 0 ? "No pending tasks" : $"from().select().where().orderByDesc().limit(5) — {maps.Count} row(s)", false);
+        if (maps.Count > 0) ShowRows(maps[0].Keys.ToList(), maps);
+    }
+
+    private async Task RunWhereEquality()
+    {
+        var maps = await AppAmbitDb.From("tasks").Where("is_completed", 0).Get();
+        ShowStatus(maps.Count == 0 ? "No pending tasks" : $"where(is_completed, 0) — {maps.Count} row(s)", false);
+        ShowRows(maps.Count > 0 ? maps[0].Keys.ToList() : new List<string>(), maps);
+    }
+
+    private async Task RunWhereIn()
+    {
+        var maps = await AppAmbitDb.From("tasks").WhereIn("priority", new object?[] { "high", "medium" }).OrderBy("due_date").Get();
+        ShowStatus(maps.Count == 0 ? "No high/medium tasks" : $"whereIn(priority, [high,medium]) — {maps.Count} row(s)", false);
+        ShowRows(maps.Count > 0 ? maps[0].Keys.ToList() : new List<string>(), maps);
+    }
+
+    private async Task RunOffset()
+    {
+        var maps = await AppAmbitDb.From("tasks").OrderBy("due_date").Limit(5).Offset(0).Get();
+        ShowStatus(maps.Count == 0 ? "No tasks" : $"limit(5).offset(0) — page 1, {maps.Count} row(s)", false);
+        ShowRows(maps.Count > 0 ? maps[0].Keys.ToList() : new List<string>(), maps);
+    }
+
+    private async Task RunFirst()
+    {
+        var item = await AppAmbitDb.From("tasks").Where("is_completed", "=", 0).OrderBy("due_date").First();
+        if (item == null) { ShowStatus("first() — no pending tasks", false); ShowRows(new List<string>(), new List<Dictionary<string, object?>>()); return; }
+        ShowStatus("first() — next task to expire", false);
+        ShowRows(item.Keys.ToList(), new List<Dictionary<string, object?>> { item });
+    }
+
+    private async Task RunCount()
+    {
+        var count = await AppAmbitDb.From("tasks").Where("is_completed", 0).Count();
+        ShowStatus($"count() — {count} pending task(s)", false);
+        ShowRows(new List<string> { "pending_tasks" }, new List<Dictionary<string, object?>> { new() { { "pending_tasks", count } } });
+    }
+
+    // ── Mutations ─────────────────────────────────────────────────────────────
+
+    private async Task RunInsert()
+    {
+        var result = await AppAmbitDb.From("tasks").Insert(new Dictionary<string, object?> { { "title", "New task" }, { "is_completed", 0 }, { "priority", "medium" }, { "due_date", DateTime.UtcNow.AddDays(7).ToString("yyyy-MM-dd") } });
+        ShowStatus($"insert() — rows_written={result.RowsWritten}", false);
+        ShowRows(new List<string> { "rows_written" }, new List<Dictionary<string, object?>> { new() { { "rows_written", result.RowsWritten } } });
+    }
+
+    private async Task RunUpdate()
+    {
+        var result = await AppAmbitDb.From("tasks").Where("title", "New task").Update(new Dictionary<string, object?> { { "is_completed", 1 } });
+        ShowStatus($"update() — rows_written={result.RowsWritten}  (run insert first)", false);
+        ShowRows(new List<string> { "rows_written" }, new List<Dictionary<string, object?>> { new() { { "rows_written", result.RowsWritten } } });
+    }
+
+    private async Task RunDelete()
+    {
+        var result = await AppAmbitDb.From("tasks").Where("is_completed", 1).Delete();
+        ShowStatus($"delete() — rows_written={result.RowsWritten}  (run update first)", false);
+        ShowRows(new List<string> { "rows_written" }, new List<Dictionary<string, object?>> { new() { { "rows_written", result.RowsWritten } } });
+    }
+
+    // ── Typed model ───────────────────────────────────────────────────────────
+
+    private async Task RunTypedModel()
+    {
+        var tasks = await AppAmbitDb.From<MacTaskModel>("tasks").Select("id", "title", "is_completed", "priority", "due_date").Limit(5).Get();
+        var cols = new List<string> { "id", "title", "isCompleted", "priority", "dueDate" };
+        var maps = tasks.Select(t => new Dictionary<string, object?> { { "id", t.Id }, { "title", t.Title }, { "isCompleted", t.IsCompleted }, { "priority", t.Priority }, { "dueDate", t.DueDate } }).ToList();
+        ShowStatus($"from<TaskModel>() — {tasks.Count} typed row(s)", false);
+        ShowRows(cols, maps);
+    }
+
+    // ── Presets ───────────────────────────────────────────────────────────────
+
+    private async Task RunPresetTables()
+    {
+        const string q = "SELECT name FROM sqlite_master WHERE type = 'table'";
+        InvokeOnMainThread(() => _editSql.Text = q);
+        var result = await AppAmbitDb.Execute(q);
+        if (result.HasError) { ShowStatus($"Error: {result.Error}", true); return; }
+        ShowStatus($"sqlite_master tables — {result.RowsRead} row(s)", false);
+        ShowRows(result.Columns, result.ToMaps());
+    }
+
+    private async Task RunPresetHighPriority()
+    {
+        const string q = "SELECT * FROM tasks WHERE priority = 'high'";
+        InvokeOnMainThread(() => _editSql.Text = q);
+        var result = await AppAmbitDb.Execute(q);
+        if (result.HasError) { ShowStatus($"Error: {result.Error}", true); return; }
+        ShowStatus($"tasks WHERE priority='high' — {result.RowsRead} row(s)", false);
+        ShowRows(result.Columns, result.ToMaps());
+    }
+}
+
+// ── TaskModel ─────────────────────────────────────────────────────────────────
+
+public class MacTaskModel
+{
+    public int Id { get; set; }
+    public string? Title { get; set; }
+    [DbColumn("is_completed")] public int IsCompleted { get; set; }
+    public string? Priority { get; set; }
+    [DbColumn("due_date")] public string? DueDate { get; set; }
+}
+
+// ── Table view data source ────────────────────────────────────────────────────
+
+public class DbMacTableViewSource : UITableViewSource
+{
+    private List<string> _columns = new();
+    private List<Dictionary<string, object?>> _rows = new();
+
+    public void UpdateData(List<string> columns, List<Dictionary<string, object?>> rows)
+    {
+        _columns = columns;
+        _rows = rows;
+    }
+
+    public override nint RowsInSection(UITableView tableview, nint section) => _rows.Count;
+
+    public override UITableViewCell GetCell(UITableView tableView, NSIndexPath indexPath)
+    {
+        var cell = (DbMacRowCell)tableView.DequeueReusableCell(DbMacRowCell.Key, indexPath);
+        cell.Bind(_columns, _rows[indexPath.Row]);
+        return cell;
+    }
+}
+
+// ── Table view cell ───────────────────────────────────────────────────────────
+
+public class DbMacRowCell : UITableViewCell
+{
+    public static readonly NSString Key = new NSString(nameof(DbMacRowCell));
+
+    private UIScrollView _scroll = null!;
+    private UIStackView _stack = null!;
+
+    [Export("initWithStyle:reuseIdentifier:")]
+    public DbMacRowCell(UITableViewCellStyle style, NSString reuseIdentifier) : base(style, reuseIdentifier)
+    {
+        SelectionStyle = UITableViewCellSelectionStyle.None;
+
+        _scroll = new UIScrollView { TranslatesAutoresizingMaskIntoConstraints = false, ShowsVerticalScrollIndicator = false };
+        _stack = new UIStackView
+        {
+            Axis = UILayoutConstraintAxis.Horizontal,
+            Spacing = 16,
+            Alignment = UIStackViewAlignment.Top,
+            Distribution = UIStackViewDistribution.EqualSpacing,
+            TranslatesAutoresizingMaskIntoConstraints = false
+        };
+
+        _scroll.AddSubview(_stack);
+        ContentView.AddSubview(_scroll);
+
+        NSLayoutConstraint.ActivateConstraints(new[]
+        {
+            _scroll.TopAnchor.ConstraintEqualTo(ContentView.TopAnchor, 4),
+            _scroll.LeadingAnchor.ConstraintEqualTo(ContentView.LeadingAnchor, 8),
+            _scroll.TrailingAnchor.ConstraintEqualTo(ContentView.TrailingAnchor, -8),
+            _scroll.BottomAnchor.ConstraintEqualTo(ContentView.BottomAnchor, -4),
+            _scroll.HeightAnchor.ConstraintEqualTo(52),
+
+            _stack.TopAnchor.ConstraintEqualTo(_scroll.TopAnchor),
+            _stack.LeadingAnchor.ConstraintEqualTo(_scroll.LeadingAnchor),
+            _stack.BottomAnchor.ConstraintEqualTo(_scroll.BottomAnchor),
+            _stack.HeightAnchor.ConstraintEqualTo(_scroll.HeightAnchor),
+        });
+    }
+
+    public void Bind(List<string> columns, Dictionary<string, object?> row)
+    {
+        foreach (var sub in _stack.ArrangedSubviews) sub.RemoveFromSuperview();
+        foreach (var col in columns)
+        {
+            var val = row.TryGetValue(col, out var v) ? v?.ToString() ?? "null" : "null";
+            var colView = new UIStackView { Axis = UILayoutConstraintAxis.Vertical, Spacing = 2, TranslatesAutoresizingMaskIntoConstraints = false };
+            colView.AddArrangedSubview(new UILabel { Text = col, Font = UIFont.BoldSystemFontOfSize(10), TextColor = UIColor.SystemGray, TranslatesAutoresizingMaskIntoConstraints = false });
+            colView.AddArrangedSubview(new UILabel { Text = val, Font = UIFont.FromName("Courier", 13) ?? UIFont.SystemFontOfSize(13), TextColor = UIColor.Label, TranslatesAutoresizingMaskIntoConstraints = false });
+            _stack.AddArrangedSubview(colView);
+        }
+    }
+}

--- a/samples/AppAmbit.App.Maui.Native.macOS/SceneDelegate.cs
+++ b/samples/AppAmbit.App.Maui.Native.macOS/SceneDelegate.cs
@@ -38,13 +38,17 @@ public class SceneDelegate : UIResponder, IUIWindowSceneDelegate
             var remoteConfigNav = new UINavigationController(remoteConfigViewController);
             remoteConfigNav.TabBarItem = new UITabBarItem("Remote Config", UIImage.GetSystemImage("antenna.radiowaves.left.and.right"), 2);
 
+            var databaseNav = new UINavigationController(new DatabaseViewController());
+            databaseNav.TabBarItem = new UITabBarItem("DB", UIImage.GetSystemImage("externaldrive"), 3);
+
             var tabBarController = new UITabBarController
             {
                 ViewControllers = new UIViewController[]
                 {
                     _crashesNav,
                     _analyticsNav,
-                    remoteConfigNav
+                    remoteConfigNav,
+                    databaseNav
                 }
             };
 

--- a/samples/AppAmbit.App.Maui/AppShell.xaml
+++ b/samples/AppAmbit.App.Maui/AppShell.xaml
@@ -11,21 +11,21 @@
         <ShellContent Title="Crashes"
                       ContentTemplate="{DataTemplate local:MainPage}"
                       Route="MainPage" />
-    
+
         <ShellContent Title="Analytics"
                       ContentTemplate="{DataTemplate local:AnalyticsPage}"
                       Route="Analytics Page" />
 
-        <ShellContent Title="Load"
-              ContentTemplate="{DataTemplate local:LoadPage}"
-              Route="LoadPage" />
-
-        <ShellContent Title="RemoteConfig"
+        <ShellContent Title="Config"
               ContentTemplate="{DataTemplate local:RemoteConfigPage}"
               Route="RemoteConfigPage" />
 
         <ShellContent Title="CMS"
               ContentTemplate="{DataTemplate local:CmsPage}"
               Route="CmsPage" />
+
+        <ShellContent Title="Database"
+              ContentTemplate="{DataTemplate local:DatabasePage}"
+              Route="DatabasePage" />
     </TabBar>
 </Shell>

--- a/samples/AppAmbit.App.Maui/DatabasePage.xaml
+++ b/samples/AppAmbit.App.Maui/DatabasePage.xaml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="AppAmbitTestingApp.DatabasePage"
+             Title="Database">
+
+    <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,*" Padding="12" RowSpacing="8">
+
+        <!-- SQL input (solo visible para demos "execute") -->
+        <Editor Grid.Row="0"
+                x:Name="EditSql"
+                Placeholder="SELECT * FROM tasks LIMIT 10"
+                HeightRequest="70"
+                BackgroundColor="#F5F5F5"
+                FontFamily="Courier New"
+                FontSize="13" />
+
+        <!-- Dropdown de funciones -->
+        <Grid Grid.Row="1" ColumnDefinitions="*,Auto" ColumnSpacing="8">
+            <Picker x:Name="FunctionPicker"
+                    Grid.Column="0"
+                    Title="Select a function..."
+                    FontSize="13" />
+            <Button Grid.Column="1"
+                    Text="▶  Run"
+                    Clicked="OnRun"
+                    FontSize="13"
+                    WidthRequest="90" />
+        </Grid>
+
+        <!-- Status bar -->
+        <Frame Grid.Row="2"
+               x:Name="StatusFrame"
+               IsVisible="False"
+               Padding="10,6"
+               CornerRadius="6"
+               BorderColor="Transparent"
+               HasShadow="False">
+            <Label x:Name="TxtStatus" FontSize="13" />
+        </Frame>
+
+        <!-- Loading indicator -->
+        <ActivityIndicator Grid.Row="3"
+                           x:Name="LoadingIndicator"
+                           IsRunning="False"
+                           IsVisible="False"
+                           Color="#1565C0"
+                           HorizontalOptions="Center" />
+
+        <!-- Column headers (generados en code-behind) -->
+        <ScrollView Grid.Row="4" Orientation="Horizontal" x:Name="HeaderScroll" IsVisible="False">
+            <Grid x:Name="HeaderRow" HeightRequest="32" BackgroundColor="#EEEEEE" />
+        </ScrollView>
+
+        <!-- Results -->
+        <CollectionView Grid.Row="5"
+                        x:Name="ResultsView"
+                        SelectionMode="None">
+            <CollectionView.ItemTemplate>
+                <DataTemplate x:DataType="x:String">
+                    <Grid ColumnDefinitions="*" Padding="0">
+                        <ScrollView Orientation="Horizontal">
+                            <Label Text="{Binding .}"
+                                   FontFamily="Courier New"
+                                   FontSize="12"
+                                   TextColor="#212121"
+                                   Padding="8,6"
+                                   BackgroundColor="White" />
+                        </ScrollView>
+                    </Grid>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+
+    </Grid>
+</ContentPage>

--- a/samples/AppAmbit.App.Maui/DatabasePage.xaml.cs
+++ b/samples/AppAmbit.App.Maui/DatabasePage.xaml.cs
@@ -1,0 +1,330 @@
+using AppAmbit;
+using AppAmbit.Models.Db;
+using AppAmbitTestingApp.Models;
+
+namespace AppAmbitTestingApp;
+
+public partial class DatabasePage : ContentPage
+{
+    private record DemoItem(string Label, Func<Task> Action);
+
+    private List<DemoItem> _demos = new();
+
+    public DatabasePage()
+    {
+        InitializeComponent();
+        BuildDemos();
+        FunctionPicker.ItemsSource = _demos.Select(d => d.Label).ToList();
+        FunctionPicker.SelectedIndex = 0;
+    }
+
+    private void BuildDemos()
+    {
+        _demos = new List<DemoItem>
+        {
+            // Raw SQL
+            new("Raw SQL → execute(sql)",                        RunExecute),
+            new("Raw SQL → execute(sql, params)",                RunExecuteParams),
+            // Batch
+            new("Batch → batch()",                               RunBatch),
+            new("Batch → batchInTransaction()",                  RunBatchInTransaction),
+            // Fluent Builder — SELECT
+            new("Fluent SELECT → select+where+orderByDesc+limit", RunFluentSelect),
+            new("Fluent SELECT → where(col,val)",                RunWhereEquality),
+            new("Fluent SELECT → whereIn()",                     RunWhereIn),
+            new("Fluent SELECT → limit+offset",                  RunOffset),
+            new("Fluent SELECT → first()",                       RunFirst),
+            new("Fluent SELECT → count()",                       RunCount),
+            // Fluent Builder — WRITE
+            new("Fluent WRITE → insert()",                       RunInsert),
+            new("Fluent WRITE → update()",                       RunUpdate),
+            new("Fluent WRITE → delete()",                       RunDelete),
+            // Typed Model Mapping
+            new("Typed Model → from(tasks, TaskModel.class)",    RunTypedModel),
+            // Presets
+            new("Preset → List tables",                          RunPresetTables),
+            new("Preset → SELECT * WHERE priority='high'",       RunPresetHighPriority),
+        };
+    }
+
+    private async void OnRun(object sender, EventArgs e)
+    {
+        if (FunctionPicker.SelectedIndex < 0) return;
+        var demo = _demos[FunctionPicker.SelectedIndex];
+        SetLoading(true);
+        ShowStatus($"Running: {demo.Label}", false);
+        try
+        {
+            await demo.Action();
+        }
+        catch (Exception ex)
+        {
+            ShowStatus($"Error: {ex.Message}", true);
+        }
+        finally
+        {
+            SetLoading(false);
+        }
+    }
+
+    private void SetLoading(bool loading)
+    {
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            LoadingIndicator.IsVisible = loading;
+            LoadingIndicator.IsRunning = loading;
+        });
+    }
+
+    // ── Raw Execute ───────────────────────────────────────────────────────────
+
+    private async Task RunExecute()
+    {
+        var sql = EditSql.Text?.Trim();
+        if (string.IsNullOrWhiteSpace(sql))
+        {
+            sql = "SELECT * FROM tasks LIMIT 10";
+            EditSql.Text = sql;
+        }
+        var result = await AppAmbitDb.Execute(sql);
+        if (result.HasError) { ShowStatus($"Error: {result.Error}", true); return; }
+        ShowStatus($"execute(sql) — rows_read={result.RowsRead}  rows_written={result.RowsWritten}", false);
+        ShowRows(result.Columns, result.ToMaps());
+    }
+
+    private async Task RunExecuteParams()
+    {
+        var result = await AppAmbitDb.Execute(
+            "SELECT * FROM tasks WHERE is_completed = ? LIMIT ?", 0, 10);
+        if (result.HasError) { ShowStatus($"Error: {result.Error}", true); return; }
+        ShowStatus($"execute(sql, 0, 10) — rows_read={result.RowsRead}", false);
+        ShowRows(result.Columns, result.ToMaps());
+    }
+
+    // ── Batch ─────────────────────────────────────────────────────────────────
+
+    private async Task RunBatch()
+    {
+        var results = await AppAmbitDb.Batch(
+            DbStatement.Of("INSERT INTO tasks (title, is_completed, priority, due_date) VALUES (?, ?, ?, ?)", "Buy coffee", 0, "low", "2026-06-10"),
+            DbStatement.Of("INSERT INTO tasks (title, is_completed, priority, due_date) VALUES (?, ?, ?, ?)", "Review PR", 0, "high", "2026-06-05"),
+            DbStatement.Of("SELECT COUNT(*) AS total FROM tasks"));
+
+        int written = results.Sum(r => r.RowsWritten);
+        var cols = new List<string> { "statement", "rows_written", "rows_read" };
+        var maps = results.Select((r, i) => new Dictionary<string, object?>
+        {
+            { "statement", i + 1 },
+            { "rows_written", r.RowsWritten },
+            { "rows_read", r.RowsRead }
+        }).ToList();
+        ShowStatus($"batch() — {written} row(s) written, {results.Count} statements, no transaction", false);
+        ShowRows(cols, maps);
+    }
+
+    private async Task RunBatchInTransaction()
+    {
+        var results = await AppAmbitDb.BatchInTransaction(
+            DbStatement.Of("INSERT INTO tasks (title, is_completed, priority, due_date) VALUES (?, ?, ?, ?)", "Team meeting", 0, "high", "2026-06-06"),
+            DbStatement.Of("INSERT INTO tasks (title, is_completed, priority, due_date) VALUES (?, ?, ?, ?)", "Prepare agenda", 0, "medium", "2026-06-06"));
+
+        int written = results.Sum(r => r.RowsWritten);
+        ShowStatus($"batchInTransaction() — {written} row(s) written, rolled back on any failure", false);
+        var cols = new List<string> { "statement", "rows_written" };
+        var maps = results.Select((r, i) => new Dictionary<string, object?>
+        {
+            { "statement", i + 1 },
+            { "rows_written", r.RowsWritten }
+        }).ToList();
+        ShowRows(cols, maps);
+    }
+
+    // ── Fluent SELECT ─────────────────────────────────────────────────────────
+
+    private async Task RunFluentSelect()
+    {
+        var maps = await AppAmbitDb.From("tasks")
+            .Select("id", "title", "priority", "due_date")
+            .Where("is_completed", "=", 0)
+            .OrderByDesc("due_date")
+            .Limit(5)
+            .Get();
+
+        ShowStatus(maps.Count == 0
+            ? "No pending tasks"
+            : $"from().select().where().orderByDesc().limit(5) — {maps.Count} row(s)", false);
+        if (maps.Count > 0) ShowRows(maps[0].Keys.ToList(), maps);
+    }
+
+    private async Task RunWhereEquality()
+    {
+        var maps = await AppAmbitDb.From("tasks").Where("is_completed", 0).Get();
+        ShowStatus(maps.Count == 0
+            ? "No pending tasks"
+            : $"where(is_completed, 0) — {maps.Count} row(s)", false);
+        if (maps.Count > 0) ShowRows(maps[0].Keys.ToList(), maps);
+        else ShowRows(new List<string>(), new List<Dictionary<string, object?>>());
+    }
+
+    private async Task RunWhereIn()
+    {
+        var maps = await AppAmbitDb.From("tasks")
+            .WhereIn("priority", new object?[] { "high", "medium" })
+            .OrderBy("due_date")
+            .Get();
+        ShowStatus(maps.Count == 0
+            ? "No high/medium tasks"
+            : $"whereIn(priority, [high,medium]) — {maps.Count} row(s)", false);
+        if (maps.Count > 0) ShowRows(maps[0].Keys.ToList(), maps);
+        else ShowRows(new List<string>(), new List<Dictionary<string, object?>>());
+    }
+
+    private async Task RunOffset()
+    {
+        var maps = await AppAmbitDb.From("tasks")
+            .OrderBy("due_date")
+            .Limit(5)
+            .Offset(0)
+            .Get();
+        ShowStatus(maps.Count == 0
+            ? "No tasks"
+            : $"limit(5).offset(0) — page 1, {maps.Count} row(s)", false);
+        if (maps.Count > 0) ShowRows(maps[0].Keys.ToList(), maps);
+        else ShowRows(new List<string>(), new List<Dictionary<string, object?>>());
+    }
+
+    private async Task RunFirst()
+    {
+        var item = await AppAmbitDb.From("tasks")
+            .Where("is_completed", "=", 0)
+            .OrderBy("due_date")
+            .First();
+        if (item == null) { ShowStatus("first() — no pending tasks", false); ShowRows(new(), new()); return; }
+        ShowStatus("first() — next task to expire", false);
+        ShowRows(item.Keys.ToList(), new List<Dictionary<string, object?>> { item });
+    }
+
+    private async Task RunCount()
+    {
+        var count = await AppAmbitDb.From("tasks").Where("is_completed", 0).Count();
+        var row = new Dictionary<string, object?> { { "pending_tasks", count } };
+        ShowStatus($"count() — {count} pending task(s)", false);
+        ShowRows(new List<string> { "pending_tasks" }, new List<Dictionary<string, object?>> { row });
+    }
+
+    // ── Mutations ─────────────────────────────────────────────────────────────
+
+    private async Task RunInsert()
+    {
+        var result = await AppAmbitDb.From("tasks").Insert(new Dictionary<string, object?>
+        {
+            { "title", "New task" },
+            { "is_completed", 0 },
+            { "priority", "medium" },
+            { "due_date", DateTime.UtcNow.AddDays(7).ToString("yyyy-MM-dd") }
+        });
+        ShowStatus($"insert() — rows_written={result.RowsWritten}", false);
+        ShowRows(new List<string> { "rows_written" },
+            new List<Dictionary<string, object?>> { new() { { "rows_written", result.RowsWritten } } });
+    }
+
+    private async Task RunUpdate()
+    {
+        var result = await AppAmbitDb.From("tasks")
+            .Where("title", "New task")
+            .Update(new Dictionary<string, object?> { { "is_completed", 1 } });
+        ShowStatus($"update() — rows_written={result.RowsWritten}  (run insert first)", false);
+        ShowRows(new List<string> { "rows_written" },
+            new List<Dictionary<string, object?>> { new() { { "rows_written", result.RowsWritten } } });
+    }
+
+    private async Task RunDelete()
+    {
+        var result = await AppAmbitDb.From("tasks").Where("is_completed", 1).Delete();
+        ShowStatus($"delete() — rows_written={result.RowsWritten}  (run update first)", false);
+        ShowRows(new List<string> { "rows_written" },
+            new List<Dictionary<string, object?>> { new() { { "rows_written", result.RowsWritten } } });
+    }
+
+    // ── Typed model ───────────────────────────────────────────────────────────
+
+    private async Task RunTypedModel()
+    {
+        var tasks = await AppAmbitDb.From<TaskModel>("tasks")
+            .Select("id", "title", "is_completed", "priority", "due_date")
+            .Limit(5)
+            .Get();
+
+        var cols = new List<string> { "id", "title", "isCompleted", "priority", "dueDate" };
+        var maps = tasks.Select(t => new Dictionary<string, object?>
+        {
+            { "id", t.Id },
+            { "title", t.Title },
+            { "isCompleted", t.IsCompleted },
+            { "priority", t.Priority },
+            { "dueDate", t.DueDate }
+        }).ToList();
+
+        ShowStatus($"from<TaskModel>() — {tasks.Count} typed row(s)", false);
+        ShowRows(cols, maps);
+    }
+
+    // ── Presets ───────────────────────────────────────────────────────────────
+
+    private async Task RunPresetTables()
+    {
+        const string q = "SELECT name FROM sqlite_master WHERE type = 'table'";
+        EditSql.Text = q;
+        var result = await AppAmbitDb.Execute(q);
+        if (result.HasError) { ShowStatus($"Error: {result.Error}", true); return; }
+        ShowStatus($"sqlite_master tables — {result.RowsRead} row(s)", false);
+        ShowRows(result.Columns, result.ToMaps());
+    }
+
+    private async Task RunPresetHighPriority()
+    {
+        const string q = "SELECT * FROM tasks WHERE priority = 'high'";
+        EditSql.Text = q;
+        var result = await AppAmbitDb.Execute(q);
+        if (result.HasError) { ShowStatus($"Error: {result.Error}", true); return; }
+        ShowStatus($"tasks WHERE priority='high' — {result.RowsRead} row(s)", false);
+        ShowRows(result.Columns, result.ToMaps());
+    }
+
+    // ── UI helpers ────────────────────────────────────────────────────────────
+
+    private void ShowStatus(string message, bool isError)
+    {
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            StatusFrame.IsVisible = true;
+            StatusFrame.BackgroundColor = isError ? Color.FromArgb("#FFEBEE") : Color.FromArgb("#E8F5E9");
+            TxtStatus.TextColor = isError ? Color.FromArgb("#C62828") : Color.FromArgb("#1B5E20");
+            TxtStatus.Text = message;
+        });
+    }
+
+    private void ShowRows(List<string> columns, List<Dictionary<string, object?>> rows)
+    {
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            if (rows.Count == 0)
+            {
+                HeaderScroll.IsVisible = false;
+                ResultsView.ItemsSource = new List<string> { "(no rows)" };
+                return;
+            }
+
+            // Each row → one monospace line: "col1: val  |  col2: val  |  ..."
+            var lines = rows.Select(row =>
+                string.Join("   |   ", columns.Select(c =>
+                {
+                    var val = row.TryGetValue(c, out var v) ? v?.ToString() ?? "null" : "null";
+                    return $"{c}: {val}";
+                }))).ToList();
+
+            HeaderScroll.IsVisible = false;
+            ResultsView.ItemsSource = lines;
+        });
+    }
+}

--- a/samples/AppAmbit.App.Maui/Models/TaskModel.cs
+++ b/samples/AppAmbit.App.Maui/Models/TaskModel.cs
@@ -1,0 +1,17 @@
+using AppAmbit.Attributes;
+
+namespace AppAmbitTestingApp.Models;
+
+public class TaskModel
+{
+    public int Id { get; set; }
+    public string? Title { get; set; }
+
+    [DbColumn("is_completed")]
+    public int IsCompleted { get; set; }
+
+    public string? Priority { get; set; }
+
+    [DbColumn("due_date")]
+    public string? DueDate { get; set; }
+}

--- a/sdk/AppAmbit/AppAmbitDb.cs
+++ b/sdk/AppAmbit/AppAmbitDb.cs
@@ -1,0 +1,57 @@
+using System.Diagnostics;
+using AppAmbit.Models.Db;
+using AppAmbit.Services.Interfaces;
+
+namespace AppAmbit;
+
+public static class AppAmbitDb
+{
+    private static IDbService? _dbService;
+
+    internal static void Initialize(IDbService dbService)
+    {
+        if (_dbService != null && _dbService != dbService)
+            Debug.WriteLine("[AppAmbitDb] Warning: Re-initializing DbService. Previous instance discarded.");
+        _dbService = dbService;
+    }
+
+    private static IDbService EnsureInitialized() =>
+        _dbService ?? throw new InvalidOperationException(
+            "AppAmbit SDK is not initialized. Call AppAmbit.start() first.");
+
+    /// <summary>Execute raw SQL with no parameters.</summary>
+    public static Task<DbResult> Execute(string sql, CancellationToken ct = default) =>
+        EnsureInitialized().QueryAsync(sql, null, ct);
+
+    /// <summary>Execute raw SQL with positional ? parameters.</summary>
+    public static Task<DbResult> Execute(string sql, params object?[] parameters) =>
+        EnsureInitialized().QueryAsync(sql, parameters.ToList());
+
+    /// <summary>Execute raw SQL with positional ? parameters and a cancellation token.</summary>
+    public static Task<DbResult> Execute(string sql, CancellationToken ct, params object?[] parameters) =>
+        EnsureInitialized().QueryAsync(sql, parameters.ToList(), ct);
+
+    /// <summary>Execute multiple statements in a single request (no transaction).</summary>
+    public static Task<List<DbResult>> Batch(params DbStatement[] statements) =>
+        EnsureInitialized().BatchAsync(statements, inTransaction: false);
+
+    /// <summary>Execute multiple statements wrapped in a transaction. Rolls back on any error.</summary>
+    public static Task<List<DbResult>> BatchInTransaction(params DbStatement[] statements) =>
+        EnsureInitialized().BatchAsync(statements, inTransaction: true);
+
+    /// <summary>Execute multiple statements with cancellation support.</summary>
+    public static Task<List<DbResult>> Batch(CancellationToken ct, params DbStatement[] statements) =>
+        EnsureInitialized().BatchAsync(statements, inTransaction: false, ct);
+
+    /// <summary>Execute multiple statements in a transaction with cancellation support.</summary>
+    public static Task<List<DbResult>> BatchInTransaction(CancellationToken ct, params DbStatement[] statements) =>
+        EnsureInitialized().BatchAsync(statements, inTransaction: true, ct);
+
+    /// <summary>Fluent query builder returning results as Dictionary&lt;string, object?&gt;.</summary>
+    public static DbQueryBuilder<Dictionary<string, object?>> From(string table) =>
+        new(table, EnsureInitialized());
+
+    /// <summary>Fluent query builder mapping results to a strongly-typed model.</summary>
+    public static DbQueryBuilder<T> From<T>(string table) where T : new() =>
+        new(table, EnsureInitialized());
+}

--- a/sdk/AppAmbit/AppAmbitSdk.cs
+++ b/sdk/AppAmbit/AppAmbitSdk.cs
@@ -173,10 +173,10 @@ public static class AppAmbitSdk
             SessionManager.Initialize(apiService, storageService);
             Crashes.Initialize(apiService, storageService, deviceId ?? "");
             Analytics.Initialize(apiService, storageService);
-            ConsumerService.Initialize(storageService, appInfoService, apiService);
             RemoteConfig.Initialize(storageService, appInfoService, apiService);
             BreadcrumbManager.Initialize(apiService!, storageService!);
             Cms.Initialize(apiService);
+            AppAmbitDb.Initialize(new DbService(apiService));
 
             _servicesReady = true;
             Debug.WriteLine("[AppAmbitSdk] Services initialized successfully.");

--- a/sdk/AppAmbit/Attributes/DbColumnAttribute.cs
+++ b/sdk/AppAmbit/Attributes/DbColumnAttribute.cs
@@ -1,0 +1,8 @@
+namespace AppAmbit.Attributes;
+
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+public sealed class DbColumnAttribute : Attribute
+{
+    public string Name { get; }
+    public DbColumnAttribute(string name) => Name = name;
+}

--- a/sdk/AppAmbit/DbQueryBuilder.cs
+++ b/sdk/AppAmbit/DbQueryBuilder.cs
@@ -52,8 +52,21 @@ public sealed class DbQueryBuilder<T> where T : new()
     {
         if (!AllowedOperators.Contains(op))
             throw new ArgumentException($"Operator not allowed: {op}", nameof(op));
-        _whereConditions.Add($"{QuoteId(column)} {op} ?");
-        _whereParams.Add(value);
+        if (value is null)
+        {
+            var rewritten = op switch
+            {
+                "=" => "IS NULL",
+                "!=" or "<>" => "IS NOT NULL",
+                _ => throw new ArgumentException($"Operator '{op}' cannot be used with null. Use IS or IS NOT.", nameof(op))
+            };
+            _whereConditions.Add($"{QuoteId(column)} {rewritten}");
+        }
+        else
+        {
+            _whereConditions.Add($"{QuoteId(column)} {op} ?");
+            _whereParams.Add(value);
+        }
         return this;
     }
 
@@ -73,8 +86,21 @@ public sealed class DbQueryBuilder<T> where T : new()
     {
         if (!AllowedOperators.Contains(op))
             throw new ArgumentException($"Operator not allowed: {op}", nameof(op));
-        _whereConditions.Add($"OR {QuoteId(column)} {op} ?");
-        _whereParams.Add(value);
+        if (value is null)
+        {
+            var rewritten = op switch
+            {
+                "=" => "IS NULL",
+                "!=" or "<>" => "IS NOT NULL",
+                _ => throw new ArgumentException($"Operator '{op}' cannot be used with null. Use IS or IS NOT.", nameof(op))
+            };
+            _whereConditions.Add($"OR {QuoteId(column)} {rewritten}");
+        }
+        else
+        {
+            _whereConditions.Add($"OR {QuoteId(column)} {op} ?");
+            _whereParams.Add(value);
+        }
         return this;
     }
 
@@ -91,6 +117,11 @@ public sealed class DbQueryBuilder<T> where T : new()
     public DbQueryBuilder<T> WhereIn(string column, IEnumerable<object?> values)
     {
         var list = values.ToList();
+        if (list.Count == 0)
+        {
+            _whereConditions.Add("1 = 0");
+            return this;
+        }
         var placeholders = string.Join(", ", list.Select(_ => "?"));
         _whereConditions.Add($"{QuoteId(column)} IN ({placeholders})");
         _whereParams.AddRange(list);
@@ -166,6 +197,8 @@ public sealed class DbQueryBuilder<T> where T : new()
     public async Task<DbResult> Insert(Dictionary<string, object?> data, CancellationToken ct = default)
     {
         EnsureNotConsumed();
+        if (data.Count == 0)
+            throw new ArgumentException("data cannot be empty.", nameof(data));
         var cols = data.Keys.ToList();
         var colList = string.Join(", ", cols.Select(QuoteId));
         var placeholders = string.Join(", ", cols.Select(_ => "?"));

--- a/sdk/AppAmbit/DbQueryBuilder.cs
+++ b/sdk/AppAmbit/DbQueryBuilder.cs
@@ -1,0 +1,261 @@
+using AppAmbit.Models.Db;
+using AppAmbit.Services.Interfaces;
+
+namespace AppAmbit;
+
+public sealed class DbQueryBuilder<T> where T : new()
+{
+    private static readonly HashSet<string> AllowedOperators = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "=", "!=", "<>", ">", ">=", "<", "<=", "LIKE", "NOT LIKE", "IS", "IS NOT"
+    };
+
+    private readonly string _table;
+    private readonly IDbService _dbService;
+
+    private readonly List<string> _selectedColumns = new();
+    private readonly List<string> _whereConditions = new();
+    private readonly List<object?> _whereParams = new();
+    private string? _orderByColumn;
+    private bool _orderByDesc;
+    private int _limitValue = -1;
+    private int _offsetValue = -1;
+    private bool _consumed;
+
+    internal DbQueryBuilder(string table, IDbService dbService)
+    {
+        _table = table;
+        _dbService = dbService;
+    }
+
+    public DbQueryBuilder<T> Select(params string[] columns)
+    {
+        foreach (var col in columns)
+            if (!_selectedColumns.Contains(col))
+                _selectedColumns.Add(col);
+        return this;
+    }
+
+    public DbQueryBuilder<T> Where(string column, object? value)
+    {
+        _whereConditions.Add($"{QuoteId(column)} = ?");
+        _whereParams.Add(value);
+        return this;
+    }
+
+    public DbQueryBuilder<T> Where(string column, string op, object? value)
+    {
+        if (!AllowedOperators.Contains(op))
+            throw new ArgumentException($"Operator not allowed: {op}", nameof(op));
+        _whereConditions.Add($"{QuoteId(column)} {op} ?");
+        _whereParams.Add(value);
+        return this;
+    }
+
+    public DbQueryBuilder<T> OrWhere(string column, object? value)
+    {
+        _whereConditions.Add($"OR {QuoteId(column)} = ?");
+        _whereParams.Add(value);
+        return this;
+    }
+
+    public DbQueryBuilder<T> OrWhere(string column, string op, object? value)
+    {
+        if (!AllowedOperators.Contains(op))
+            throw new ArgumentException($"Operator not allowed: {op}", nameof(op));
+        _whereConditions.Add($"OR {QuoteId(column)} {op} ?");
+        _whereParams.Add(value);
+        return this;
+    }
+
+    public DbQueryBuilder<T> WhereGroup(Action<DbQueryBuilder<T>> configure)
+    {
+        var group = new DbQueryBuilder<T>(_table, _dbService);
+        configure(group);
+        if (group._whereConditions.Count == 0) return this;
+        _whereConditions.Add($"({group.JoinConditions()})");
+        _whereParams.AddRange(group._whereParams);
+        return this;
+    }
+
+    public DbQueryBuilder<T> WhereIn(string column, IEnumerable<object?> values)
+    {
+        var list = values.ToList();
+        var placeholders = string.Join(", ", list.Select(_ => "?"));
+        _whereConditions.Add($"{QuoteId(column)} IN ({placeholders})");
+        _whereParams.AddRange(list);
+        return this;
+    }
+
+    public DbQueryBuilder<T> OrderBy(string column)
+    {
+        _orderByColumn = column;
+        _orderByDesc = false;
+        return this;
+    }
+
+    public DbQueryBuilder<T> OrderByDesc(string column)
+    {
+        _orderByColumn = column;
+        _orderByDesc = true;
+        return this;
+    }
+
+    public DbQueryBuilder<T> Limit(int n)
+    {
+        _limitValue = n;
+        return this;
+    }
+
+    public DbQueryBuilder<T> Offset(int n)
+    {
+        _offsetValue = n;
+        return this;
+    }
+
+    public async Task<List<T>> Get(CancellationToken ct = default)
+    {
+        EnsureNotConsumed();
+        var sql = BuildSelectSql(-1);
+        var result = await _dbService.QueryAsync(sql, new List<object?>(_whereParams), ct);
+        if (result.HasError) return new List<T>();
+        return typeof(T) == typeof(Dictionary<string, object?>)
+            ? (List<T>)(object)result.ToMaps()
+            : result.MapTo<T>();
+    }
+
+    public async Task<T?> First(CancellationToken ct = default)
+    {
+        EnsureNotConsumed();
+        var sql = BuildSelectSql(1);
+        var result = await _dbService.QueryAsync(sql, new List<object?>(_whereParams), ct);
+        if (result.HasError) return default;
+        var list = typeof(T) == typeof(Dictionary<string, object?>)
+            ? (List<T>)(object)result.ToMaps()
+            : result.MapTo<T>();
+        return list.Count > 0 ? list[0] : default;
+    }
+
+    public async Task<int> Count(CancellationToken ct = default)
+    {
+        EnsureNotConsumed();
+        var sb = new System.Text.StringBuilder($"SELECT COUNT(*) FROM {QuoteId(_table)}");
+        if (_whereConditions.Count > 0)
+            sb.Append($" WHERE {JoinConditions()}");
+
+        var result = await _dbService.QueryAsync(sb.ToString(), new List<object?>(_whereParams), ct);
+        if (result.HasError) return 0;
+        if (result.Rows.Count == 0) return 0;
+
+        var val = result.Rows[0].FirstOrDefault();
+        if (val == null) return 0;
+        if (val is IConvertible c) return Convert.ToInt32(c);
+        throw new InvalidOperationException($"Unexpected COUNT result type: {val.GetType().Name} = '{val}'");
+    }
+
+    public async Task<DbResult> Insert(Dictionary<string, object?> data, CancellationToken ct = default)
+    {
+        EnsureNotConsumed();
+        var cols = data.Keys.ToList();
+        var colList = string.Join(", ", cols.Select(QuoteId));
+        var placeholders = string.Join(", ", cols.Select(_ => "?"));
+        var sql = $"INSERT INTO {QuoteId(_table)} ({colList}) VALUES ({placeholders})";
+        var parameters = cols.Select(c => data[c]).ToList();
+
+        return await _dbService.QueryAsync(sql, parameters, ct);
+    }
+
+    public async Task<DbResult> Update(Dictionary<string, object?> data, CancellationToken ct = default)
+    {
+        EnsureNotConsumed();
+        if (_whereConditions.Count == 0)
+            throw new InvalidOperationException(
+                "Update() without Where() would affect all rows. Use AppAmbitDb.Execute() for intentional full-table updates.");
+
+        var cols = data.Keys.ToList();
+        var setClauses = string.Join(", ", cols.Select(c => $"{QuoteId(c)} = ?"));
+        var sql = $"UPDATE {QuoteId(_table)} SET {setClauses} WHERE {JoinConditions()}";
+        var parameters = cols.Select(c => data[c]).Concat(_whereParams).ToList();
+
+        return await _dbService.QueryAsync(sql, parameters, ct);
+    }
+
+    public async Task<DbResult> Delete(CancellationToken ct = default)
+    {
+        EnsureNotConsumed();
+        if (_whereConditions.Count == 0)
+            throw new InvalidOperationException(
+                "Delete() without Where() would delete all rows. Use AppAmbitDb.Execute() for intentional full-table deletes.");
+
+        var sql = $"DELETE FROM {QuoteId(_table)} WHERE {JoinConditions()}";
+        return await _dbService.QueryAsync(sql, new List<object?>(_whereParams), ct);
+    }
+
+    private string BuildSelectSql(int overrideLimit)
+    {
+        var cols = _selectedColumns.Count > 0
+            ? string.Join(", ", _selectedColumns.Select(QuoteId))
+            : "*";
+
+        var sb = new System.Text.StringBuilder($"SELECT {cols} FROM {QuoteId(_table)}");
+
+        if (_whereConditions.Count > 0)
+            sb.Append($" WHERE {JoinConditions()}");
+
+        if (_orderByColumn != null)
+        {
+            sb.Append($" ORDER BY {QuoteId(_orderByColumn)}");
+            if (_orderByDesc) sb.Append(" DESC");
+        }
+
+        int effectiveLimit = overrideLimit > 0 ? overrideLimit : _limitValue;
+        if (effectiveLimit > 0) sb.Append($" LIMIT {effectiveLimit}");
+        if (_offsetValue >= 0) sb.Append($" OFFSET {_offsetValue}");
+
+        return sb.ToString();
+    }
+
+    private string JoinConditions()
+    {
+        var sb = new System.Text.StringBuilder();
+        for (int i = 0; i < _whereConditions.Count; i++)
+        {
+            var cond = _whereConditions[i];
+            if (i == 0)
+            {
+                // Strip leading OR prefix on first condition (shouldn't happen in valid usage, but guard it)
+                sb.Append(cond.StartsWith("OR ", StringComparison.OrdinalIgnoreCase)
+                    ? cond[3..]
+                    : cond);
+            }
+            else if (cond.StartsWith("OR ", StringComparison.OrdinalIgnoreCase))
+            {
+                sb.Append(' ');
+                sb.Append(cond);
+            }
+            else
+            {
+                sb.Append(" AND ");
+                sb.Append(cond);
+            }
+        }
+        return sb.ToString();
+    }
+
+    private void EnsureNotConsumed()
+    {
+        if (_consumed)
+            throw new InvalidOperationException(
+                "DbQueryBuilder instance already executed. Create a new builder via AppAmbitDb.From().");
+        _consumed = true;
+    }
+
+    private static string QuoteId(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Identifier cannot be null or empty.", nameof(name));
+        if (name.Any(c => c < 32))
+            throw new ArgumentException($"Identifier contains invalid characters.", nameof(name));
+        return $"\"{name.Replace("\"", "\"\"")}\"";
+    }
+}

--- a/sdk/AppAmbit/DbQueryBuilder.cs
+++ b/sdk/AppAmbit/DbQueryBuilder.cs
@@ -38,8 +38,13 @@ public sealed class DbQueryBuilder<T> where T : new()
 
     public DbQueryBuilder<T> Where(string column, object? value)
     {
-        _whereConditions.Add($"{QuoteId(column)} = ?");
-        _whereParams.Add(value);
+        if (value is null)
+            _whereConditions.Add($"{QuoteId(column)} IS NULL");
+        else
+        {
+            _whereConditions.Add($"{QuoteId(column)} = ?");
+            _whereParams.Add(value);
+        }
         return this;
     }
 
@@ -54,8 +59,13 @@ public sealed class DbQueryBuilder<T> where T : new()
 
     public DbQueryBuilder<T> OrWhere(string column, object? value)
     {
-        _whereConditions.Add($"OR {QuoteId(column)} = ?");
-        _whereParams.Add(value);
+        if (value is null)
+            _whereConditions.Add($"OR {QuoteId(column)} IS NULL");
+        else
+        {
+            _whereConditions.Add($"OR {QuoteId(column)} = ?");
+            _whereParams.Add(value);
+        }
         return this;
     }
 
@@ -209,7 +219,7 @@ public sealed class DbQueryBuilder<T> where T : new()
         }
 
         int effectiveLimit = overrideLimit > 0 ? overrideLimit : _limitValue;
-        if (effectiveLimit > 0) sb.Append($" LIMIT {effectiveLimit}");
+        if (effectiveLimit >= 0) sb.Append($" LIMIT {effectiveLimit}");
         if (_offsetValue >= 0) sb.Append($" OFFSET {_offsetValue}");
 
         return sb.ToString();

--- a/sdk/AppAmbit/Models/Db/DbApiResponse.cs
+++ b/sdk/AppAmbit/Models/Db/DbApiResponse.cs
@@ -1,0 +1,42 @@
+using Newtonsoft.Json;
+
+namespace AppAmbit.Models.Db;
+
+internal sealed class DbApiResponse
+{
+    [JsonProperty("results")]
+    public List<DbResultDto>? Results { get; set; }
+
+    [JsonProperty("request_id")]
+    public string? RequestId { get; set; }
+}
+
+internal sealed class DbResultDto
+{
+    [JsonProperty("columns")]
+    public List<string>? Columns { get; set; }
+
+    [JsonProperty("rows")]
+    public List<List<object?>>? Rows { get; set; }
+
+    [JsonProperty("rows_read")]
+    public int RowsRead { get; set; }
+
+    [JsonProperty("rows_written")]
+    public int RowsWritten { get; set; }
+
+    [JsonProperty("error")]
+    public string? Error { get; set; }
+
+    public DbResult ToDbResult()
+    {
+        return new DbResult
+        {
+            Columns = Columns ?? new List<string>(),
+            Rows = Rows ?? new List<List<object?>>(),
+            RowsRead = RowsRead,
+            RowsWritten = RowsWritten,
+            Error = Error
+        };
+    }
+}

--- a/sdk/AppAmbit/Models/Db/DbBatchRequest.cs
+++ b/sdk/AppAmbit/Models/Db/DbBatchRequest.cs
@@ -1,0 +1,33 @@
+using Newtonsoft.Json;
+
+namespace AppAmbit.Models.Db;
+
+internal sealed class DbBatchRequest
+{
+    [JsonProperty("statements")]
+    public List<DbStatementPayload> Statements { get; }
+
+    [JsonProperty("transaction")]
+    public bool Transaction { get; }
+
+    public DbBatchRequest(IEnumerable<DbStatement> statements, bool inTransaction)
+    {
+        Statements = statements.Select(s => new DbStatementPayload(s)).ToList();
+        Transaction = inTransaction;
+    }
+}
+
+internal sealed class DbStatementPayload
+{
+    [JsonProperty("sql")]
+    public string Sql { get; }
+
+    [JsonProperty("params", NullValueHandling = NullValueHandling.Ignore)]
+    public List<object?>? Params { get; }
+
+    public DbStatementPayload(DbStatement s)
+    {
+        Sql = s.Sql;
+        Params = s.Params;
+    }
+}

--- a/sdk/AppAmbit/Models/Db/DbQueryRequest.cs
+++ b/sdk/AppAmbit/Models/Db/DbQueryRequest.cs
@@ -1,0 +1,18 @@
+using Newtonsoft.Json;
+
+namespace AppAmbit.Models.Db;
+
+internal sealed class DbQueryRequest
+{
+    [JsonProperty("sql")]
+    public string Sql { get; }
+
+    [JsonProperty("params", NullValueHandling = NullValueHandling.Ignore)]
+    public List<object?>? Params { get; }
+
+    public DbQueryRequest(string sql, List<object?>? parameters)
+    {
+        Sql = sql;
+        Params = parameters is { Count: > 0 } ? parameters : null;
+    }
+}

--- a/sdk/AppAmbit/Models/Db/DbResult.cs
+++ b/sdk/AppAmbit/Models/Db/DbResult.cs
@@ -1,0 +1,95 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using AppAmbit.Attributes;
+
+namespace AppAmbit.Models.Db;
+
+public sealed class DbResult
+{
+    public List<string> Columns { get; internal set; } = new();
+    public List<List<object?>> Rows { get; internal set; } = new();
+    public int RowsRead { get; internal set; }
+    public int RowsWritten { get; internal set; }
+    public string? Error { get; internal set; }
+
+    public bool HasError => Error != null;
+    public bool Succeeded => Error == null;
+
+    internal DbResult() { }
+
+    public List<Dictionary<string, object?>> ToMaps()
+    {
+        var result = new List<Dictionary<string, object?>>();
+        foreach (var row in Rows)
+        {
+            var map = new Dictionary<string, object?>();
+            for (int i = 0; i < Columns.Count && i < row.Count; i++)
+                map[Columns[i]] = row[i];
+            result.Add(map);
+        }
+        return result;
+    }
+
+    private static readonly ConcurrentDictionary<Type, Dictionary<string, MemberSetter>> _memberCache = new();
+
+    private readonly record struct MemberSetter(MemberInfo Member, Type MemberType);
+
+    private static Dictionary<string, MemberSetter> GetMemberMap(Type type) =>
+        _memberCache.GetOrAdd(type, t =>
+        {
+            var map = new Dictionary<string, MemberSetter>(StringComparer.OrdinalIgnoreCase);
+            foreach (var prop in t.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (!prop.CanWrite) continue;
+                var attr = prop.GetCustomAttribute<DbColumnAttribute>();
+                var name = attr?.Name ?? prop.Name;
+                map[name] = new MemberSetter(prop, prop.PropertyType);
+            }
+            foreach (var field in t.GetFields(BindingFlags.Public | BindingFlags.Instance))
+            {
+                var attr = field.GetCustomAttribute<DbColumnAttribute>();
+                var name = attr?.Name ?? field.Name;
+                map[name] = new MemberSetter(field, field.FieldType);
+            }
+            return map;
+        });
+
+    public List<T> MapTo<T>() where T : new()
+    {
+        var map = GetMemberMap(typeof(T));
+        var result = new List<T>();
+        foreach (var row in Rows)
+        {
+            var instance = new T();
+            for (int colIdx = 0; colIdx < Columns.Count && colIdx < row.Count; colIdx++)
+            {
+                if (!map.TryGetValue(Columns[colIdx], out var setter)) continue;
+                var value = CastValue(row[colIdx], setter.MemberType);
+                if (setter.Member is PropertyInfo prop)
+                    prop.SetValue(instance, value);
+                else if (setter.Member is FieldInfo field)
+                    field.SetValue(instance, value);
+            }
+            result.Add(instance);
+        }
+        return result;
+    }
+
+    private static object? CastValue(object? value, Type type)
+    {
+        if (value == null) return null;
+        var underlying = Nullable.GetUnderlyingType(type) ?? type;
+        if (underlying == typeof(string)) return value.ToString();
+        if (underlying == typeof(int)) return value is IConvertible c ? Convert.ToInt32(c) : int.Parse(value.ToString()!);
+        if (underlying == typeof(long)) return value is IConvertible c2 ? Convert.ToInt64(c2) : long.Parse(value.ToString()!);
+        if (underlying == typeof(double)) return value is IConvertible c3 ? Convert.ToDouble(c3) : double.Parse(value.ToString()!);
+        if (underlying == typeof(float)) return value is IConvertible c4 ? Convert.ToSingle(c4) : float.Parse(value.ToString()!);
+        if (underlying == typeof(bool))
+        {
+            if (value is bool b) return b;
+            if (value is IConvertible ic) return Convert.ToBoolean(ic); // handles SQLite 0/1
+            return bool.Parse(value.ToString()!);
+        }
+        return value;
+    }
+}

--- a/sdk/AppAmbit/Models/Db/DbStatement.cs
+++ b/sdk/AppAmbit/Models/Db/DbStatement.cs
@@ -1,0 +1,18 @@
+namespace AppAmbit.Models.Db;
+
+public sealed class DbStatement
+{
+    public string Sql { get; }
+    public List<object?>? Params { get; }
+
+    private DbStatement(string sql, List<object?>? parameters)
+    {
+        Sql = sql;
+        Params = parameters is { Count: > 0 } ? parameters : null;
+    }
+
+    public static DbStatement Of(string sql) => new(sql, null);
+
+    public static DbStatement Of(string sql, params object?[] parameters) =>
+        new(sql, parameters.Length > 0 ? new List<object?>(parameters) : null);
+}

--- a/sdk/AppAmbit/Services/DbService.cs
+++ b/sdk/AppAmbit/Services/DbService.cs
@@ -1,0 +1,57 @@
+using AppAmbit.Enums;
+using AppAmbit.Models.Db;
+using AppAmbit.Services.Endpoints;
+using AppAmbit.Services.Interfaces;
+using System.Diagnostics;
+
+namespace AppAmbit.Services;
+
+internal sealed class DbService : IDbService
+{
+    private readonly IAPIService _apiService;
+
+    public DbService(IAPIService apiService) => _apiService = apiService;
+
+    public async Task<DbResult> QueryAsync(string sql, List<object?>? parameters = null, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        var endpoint = new DbQueryEndpoint(sql, parameters);
+        var apiResult = await _apiService.ExecuteRequest<DbApiResponse>(endpoint, ct);
+
+        if (apiResult == null || apiResult.ErrorType != ApiErrorType.None)
+        {
+            var rawMsg = apiResult?.Message ?? "DB query failed";
+            Debug.WriteLine($"[DbService] QueryAsync raw error: {rawMsg}");
+            var userMsg = apiResult?.ErrorType == ApiErrorType.NetworkUnavailable
+                ? "Network unavailable. Please check your connection."
+                : "Database operation failed.";
+            return new DbResult { Error = userMsg };
+        }
+
+        var first = apiResult.Data?.Results?.FirstOrDefault();
+        return first?.ToDbResult() ?? new DbResult { Error = "Database operation failed." };
+    }
+
+    public async Task<List<DbResult>> BatchAsync(IEnumerable<DbStatement> statements, bool inTransaction, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        var endpoint = new DbBatchEndpoint(statements, inTransaction);
+        var apiResult = await _apiService.ExecuteRequest<DbApiResponse>(endpoint, ct);
+
+        if (apiResult == null || apiResult.ErrorType != ApiErrorType.None)
+        {
+            var rawMsg = apiResult?.Message ?? "DB batch failed";
+            Debug.WriteLine($"[DbService] BatchAsync raw error: {rawMsg}");
+            var userMsg = apiResult?.ErrorType == ApiErrorType.NetworkUnavailable
+                ? "Network unavailable. Please check your connection."
+                : "Database operation failed.";
+            return new List<DbResult> { new DbResult { Error = userMsg } };
+        }
+
+        var results = apiResult.Data?.Results;
+        if (results == null || results.Count == 0)
+            return new List<DbResult> { new DbResult { Error = "Database operation failed." } };
+
+        return results.Select(r => r.ToDbResult()).ToList();
+    }
+}

--- a/sdk/AppAmbit/Services/Endpoints/DbBatchEndpoint.cs
+++ b/sdk/AppAmbit/Services/Endpoints/DbBatchEndpoint.cs
@@ -1,0 +1,15 @@
+using AppAmbit.Models.Db;
+using AppAmbit.Services.Endpoints.Base;
+using AppAmbit.Services.Interfaces;
+
+namespace AppAmbit.Services.Endpoints;
+
+internal sealed class DbBatchEndpoint : BaseEndpoint
+{
+    public DbBatchEndpoint(IEnumerable<DbStatement> statements, bool inTransaction)
+    {
+        Url = "/db/batch";
+        Method = HttpMethodEnum.Post;
+        Payload = new DbBatchRequest(statements, inTransaction);
+    }
+}

--- a/sdk/AppAmbit/Services/Endpoints/DbQueryEndpoint.cs
+++ b/sdk/AppAmbit/Services/Endpoints/DbQueryEndpoint.cs
@@ -1,0 +1,15 @@
+using AppAmbit.Models.Db;
+using AppAmbit.Services.Endpoints.Base;
+using AppAmbit.Services.Interfaces;
+
+namespace AppAmbit.Services.Endpoints;
+
+internal sealed class DbQueryEndpoint : BaseEndpoint
+{
+    public DbQueryEndpoint(string sql, List<object?>? parameters)
+    {
+        Url = "/db/query";
+        Method = HttpMethodEnum.Post;
+        Payload = new DbQueryRequest(sql, parameters);
+    }
+}

--- a/sdk/AppAmbit/Services/Interfaces/IDbService.cs
+++ b/sdk/AppAmbit/Services/Interfaces/IDbService.cs
@@ -1,0 +1,9 @@
+using AppAmbit.Models.Db;
+
+namespace AppAmbit.Services.Interfaces;
+
+public interface IDbService
+{
+    Task<DbResult> QueryAsync(string sql, List<object?>? parameters = null, CancellationToken ct = default);
+    Task<List<DbResult>> BatchAsync(IEnumerable<DbStatement> statements, bool inTransaction, CancellationToken ct = default);
+}

--- a/tests/AppAmbitDbTests.cs
+++ b/tests/AppAmbitDbTests.cs
@@ -912,6 +912,93 @@ public class AppAmbitDbTests : IDisposable
             AppAmbitDb.From("tasks").Count());
     }
 
+    // ── Group 19: BUG — Limit(0) silently ignored ────────────────────────────
+    // DbQueryBuilder.cs line 212: `if (effectiveLimit > 0)` drops LIMIT 0 from SQL.
+    // This test documents the bug: Limit(0) currently emits no LIMIT clause,
+    // so the backend returns all rows instead of zero.
+
+    [Fact]
+    public async Task From_Limit_Zero_EmitsLimitClause()
+    {
+        // BUG: guard is `> 0`, so LIMIT 0 is silently dropped — this test FAILS today.
+        // Fix: change guard to `>= 0` (mirroring the already-fixed Offset(0) guard).
+        string? capturedSql = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((sql, _, _ct) => capturedSql = sql)
+            .ReturnsAsync(OkResult());
+
+        await AppAmbitDb.From("tasks").Limit(0).Get();
+
+        Assert.Contains("LIMIT 0", capturedSql);
+    }
+
+    [Fact]
+    public async Task From_Limit_Zero_SqlEndsWithLimitClause()
+    {
+        string? capturedSql = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((sql, _, _ct) => capturedSql = sql)
+            .ReturnsAsync(OkResult());
+
+        await AppAmbitDb.From("tasks").Limit(0).Get();
+
+        Assert.Contains("LIMIT 0", capturedSql);
+        Assert.NotEqual("SELECT * FROM \"tasks\"", capturedSql);
+    }
+
+    // ── Group 20: Where(column, null) auto-rewrites to IS NULL ──────────────
+    // Standard SQL: `x = NULL` → UNKNOWN → zero rows. Builder auto-rewrites to IS NULL.
+
+    [Fact]
+    public async Task Where_NullValue_GeneratesIsNull()
+    {
+        string? capturedSql = null;
+        List<object?>? capturedParams = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((sql, p, _ct) => { capturedSql = sql; capturedParams = p; })
+            .ReturnsAsync(OkResult());
+
+        await AppAmbitDb.From("tasks").Where("deleted_at", null).Get();
+
+        Assert.Contains("\"deleted_at\" IS NULL", capturedSql);
+        Assert.DoesNotContain("= ?", capturedSql);
+        Assert.Empty(capturedParams!);
+    }
+
+    [Fact]
+    public async Task OrWhere_NullValue_GeneratesOrIsNull()
+    {
+        string? capturedSql = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((sql, _, _ct) => capturedSql = sql)
+            .ReturnsAsync(OkResult());
+
+        await AppAmbitDb.From("tasks")
+            .Where("priority", "high")
+            .OrWhere("deleted_at", null)
+            .Get();
+
+        Assert.Contains("\"deleted_at\" IS NULL", capturedSql);
+    }
+
+    [Fact]
+    public async Task Where_NullValue_MixedWithNonNull_CorrectParamCount()
+    {
+        List<object?>? capturedParams = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((_, p, _ct) => capturedParams = p)
+            .ReturnsAsync(OkResult());
+
+        await AppAmbitDb.From("tasks")
+            .Where("is_completed", 0)
+            .Where("deleted_at", null)
+            .Get();
+
+        // Only one param bound: the non-null Where("is_completed", 0)
+        Assert.Single(capturedParams!);
+        Assert.Equal(0, capturedParams![0]);
+    }
+
     // ── inner test models ─────────────────────────────────────────────────────
 
     private class SimpleModel

--- a/tests/AppAmbitDbTests.cs
+++ b/tests/AppAmbitDbTests.cs
@@ -1,0 +1,936 @@
+using System.Reflection;
+using AppAmbit;
+using AppAmbit.Attributes;
+using AppAmbit.Models.Db;
+using AppAmbit.Services.Interfaces;
+using Moq;
+using Xunit;
+
+namespace AppAmbitTest;
+
+[Collection("AppAmbitDb Tests")]
+public class AppAmbitDbTests : IDisposable
+{
+    private readonly Mock<IDbService> _mockDb;
+
+    public AppAmbitDbTests()
+    {
+        _mockDb = new Mock<IDbService>();
+        ResetState();
+        AppAmbitDb.Initialize(_mockDb.Object);
+    }
+
+    public void Dispose() => ResetState();
+
+    private static void ResetState()
+    {
+        typeof(AppAmbitDb)
+            .GetField("_dbService", BindingFlags.NonPublic | BindingFlags.Static)
+            ?.SetValue(null, null);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static DbResult OkResult(List<string>? columns = null, List<List<object?>>? rows = null,
+        int rowsRead = 0, int rowsWritten = 0) =>
+        new() { Columns = columns ?? new(), Rows = rows ?? new(), RowsRead = rowsRead, RowsWritten = rowsWritten };
+
+    private static DbResult ErrorResult(string error) => new() { Error = error };
+
+    private static List<List<object?>> MakeRows(params object?[][] rows) =>
+        rows.Select(r => r.ToList()).ToList();
+
+    // ── Group 1: Execute ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Execute_WithoutParams_CallsServiceWithSql()
+    {
+        string? capturedSql = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((sql, _, _ct) => capturedSql = sql)
+            .ReturnsAsync(OkResult());
+
+        await AppAmbitDb.Execute("SELECT 1");
+
+        Assert.Equal("SELECT 1", capturedSql);
+    }
+
+    [Fact]
+    public async Task Execute_WithParams_ForwardsParamsToService()
+    {
+        List<object?>? capturedParams = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((_, p, _ct) => capturedParams = p)
+            .ReturnsAsync(OkResult());
+
+        await AppAmbitDb.Execute("SELECT * FROM tasks WHERE id = ?", 42);
+
+        Assert.NotNull(capturedParams);
+        Assert.Single(capturedParams!);
+        Assert.Equal(42, capturedParams![0]);
+    }
+
+    [Fact]
+    public async Task Execute_WhenServiceReturnsError_ResultHasError()
+    {
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ErrorResult("table not found"));
+
+        var result = await AppAmbitDb.Execute("SELECT * FROM missing");
+
+        Assert.True(result.HasError);
+        Assert.Equal("table not found", result.Error);
+    }
+
+    [Fact]
+    public void Execute_WhenNotInitialized_ThrowsInvalidOperationException()
+    {
+        ResetState();
+        Assert.Throws<InvalidOperationException>(() => { _ = AppAmbitDb.Execute("SELECT 1"); });
+    }
+
+    // ── Group 2: Batch ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Batch_SendsAllStatementsWithTransactionFalse()
+    {
+        IEnumerable<DbStatement>? capturedStatements = null;
+        bool? capturedTx = null;
+        _mockDb.Setup(s => s.BatchAsync(It.IsAny<IEnumerable<DbStatement>>(), It.IsAny<bool>()))
+            .Callback<IEnumerable<DbStatement>, bool, CancellationToken>((stmts, tx, _ct) => { capturedStatements = stmts; capturedTx = tx; })
+            .ReturnsAsync(new List<DbResult> { OkResult(rowsWritten: 1), OkResult(rowsWritten: 1) });
+
+        await AppAmbitDb.Batch(DbStatement.Of("INSERT INTO t VALUES (?)","a"), DbStatement.Of("INSERT INTO t VALUES (?)", "b"));
+
+        Assert.NotNull(capturedStatements);
+        Assert.Equal(2, capturedStatements!.Count());
+        Assert.False(capturedTx);
+    }
+
+    [Fact]
+    public async Task Batch_ReturnsResultPerStatement()
+    {
+        _mockDb.Setup(s => s.BatchAsync(It.IsAny<IEnumerable<DbStatement>>(), false))
+            .ReturnsAsync(new List<DbResult> { OkResult(rowsWritten: 1), OkResult(rowsWritten: 1), OkResult() });
+
+        var results = await AppAmbitDb.Batch(
+            DbStatement.Of("INSERT INTO t(x) VALUES (?)", 1),
+            DbStatement.Of("INSERT INTO t(x) VALUES (?)", 2),
+            DbStatement.Of("SELECT COUNT(*) FROM t"));
+
+        Assert.Equal(3, results.Count);
+    }
+
+    [Fact]
+    public async Task BatchInTransaction_SendsWithTransactionTrue()
+    {
+        bool? capturedTx = null;
+        _mockDb.Setup(s => s.BatchAsync(It.IsAny<IEnumerable<DbStatement>>(), It.IsAny<bool>()))
+            .Callback<IEnumerable<DbStatement>, bool, CancellationToken>((_, tx, _ct) => capturedTx = tx)
+            .ReturnsAsync(new List<DbResult> { OkResult(rowsWritten: 1) });
+
+        await AppAmbitDb.BatchInTransaction(DbStatement.Of("INSERT INTO t VALUES (1)"));
+
+        Assert.True(capturedTx);
+    }
+
+    [Fact]
+    public async Task BatchInTransaction_WhenOneStatementErrors_ResultContainsError()
+    {
+        _mockDb.Setup(s => s.BatchAsync(It.IsAny<IEnumerable<DbStatement>>(), true))
+            .ReturnsAsync(new List<DbResult> { OkResult(rowsWritten: 1), ErrorResult("constraint violation") });
+
+        var results = await AppAmbitDb.BatchInTransaction(
+            DbStatement.Of("INSERT INTO t VALUES (1)"),
+            DbStatement.Of("INSERT INTO t VALUES (1)"));
+
+        Assert.Contains(results, r => r.HasError);
+    }
+
+    // ── Group 3: DbQueryBuilder SELECT ──────────────────────────────────────
+
+    [Fact]
+    public async Task From_Get_GeneratesSelectStar()
+    {
+        string? capturedSql = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((sql, _, _ct) => capturedSql = sql)
+            .ReturnsAsync(OkResult());
+
+        await AppAmbitDb.From("tasks").Get();
+
+        Assert.NotNull(capturedSql);
+        Assert.Contains("SELECT *", capturedSql);
+        Assert.Contains("FROM \"tasks\"", capturedSql);
+    }
+
+    [Fact]
+    public async Task From_Select_GeneratesSpecificColumns()
+    {
+        string? capturedSql = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((sql, _, _ct) => capturedSql = sql)
+            .ReturnsAsync(OkResult());
+
+        await AppAmbitDb.From("tasks").Select("id", "title").Get();
+
+        Assert.Contains("\"id\"", capturedSql);
+        Assert.Contains("\"title\"", capturedSql);
+        Assert.DoesNotContain("SELECT *", capturedSql);
+    }
+
+    [Fact]
+    public async Task From_Where_Equality_AddsWhereClause()
+    {
+        string? capturedSql = null;
+        List<object?>? capturedParams = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((sql, p, _ct) => { capturedSql = sql; capturedParams = p; })
+            .ReturnsAsync(OkResult());
+
+        await AppAmbitDb.From("tasks").Where("is_completed", 0).Get();
+
+        Assert.Contains("WHERE", capturedSql);
+        Assert.Contains("\"is_completed\" = ?", capturedSql);
+        Assert.Equal(0, capturedParams![0]);
+    }
+
+    [Fact]
+    public async Task From_Where_WithOperator_AddsCorrectOperator()
+    {
+        string? capturedSql = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((sql, _, _ct) => capturedSql = sql)
+            .ReturnsAsync(OkResult());
+
+        await AppAmbitDb.From("tasks").Where("due_date", ">=", "2026-01-01").Get();
+
+        Assert.Contains("\"due_date\" >= ?", capturedSql);
+    }
+
+    [Fact]
+    public void From_Where_InvalidOperator_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            AppAmbitDb.From("tasks").Where("col", "DROP", "val"));
+    }
+
+    [Fact]
+    public async Task From_WhereIn_GeneratesInClause()
+    {
+        string? capturedSql = null;
+        List<object?>? capturedParams = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((sql, p, _ct) => { capturedSql = sql; capturedParams = p; })
+            .ReturnsAsync(OkResult());
+
+        await AppAmbitDb.From("tasks").WhereIn("priority", new object?[] { "high", "medium" }).Get();
+
+        Assert.Contains("IN (?, ?)", capturedSql);
+        Assert.Equal("high", capturedParams![0]);
+        Assert.Equal("medium", capturedParams![1]);
+    }
+
+    [Fact]
+    public async Task From_OrderBy_AddsOrderByAsc()
+    {
+        string? capturedSql = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((sql, _, _ct) => capturedSql = sql)
+            .ReturnsAsync(OkResult());
+
+        await AppAmbitDb.From("tasks").OrderBy("due_date").Get();
+
+        Assert.Contains("ORDER BY \"due_date\"", capturedSql);
+        Assert.DoesNotContain("DESC", capturedSql);
+    }
+
+    [Fact]
+    public async Task From_OrderByDesc_AddsOrderByDesc()
+    {
+        string? capturedSql = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((sql, _, _ct) => capturedSql = sql)
+            .ReturnsAsync(OkResult());
+
+        await AppAmbitDb.From("tasks").OrderByDesc("due_date").Get();
+
+        Assert.Contains("ORDER BY \"due_date\" DESC", capturedSql);
+    }
+
+    [Fact]
+    public async Task From_Limit_AddsLimitClause()
+    {
+        string? capturedSql = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((sql, _, _ct) => capturedSql = sql)
+            .ReturnsAsync(OkResult());
+
+        await AppAmbitDb.From("tasks").Limit(5).Get();
+
+        Assert.Contains("LIMIT 5", capturedSql);
+    }
+
+    [Fact]
+    public async Task From_Offset_AddsOffsetClause()
+    {
+        string? capturedSql = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((sql, _, _ct) => capturedSql = sql)
+            .ReturnsAsync(OkResult());
+
+        await AppAmbitDb.From("tasks").Limit(5).Offset(10).Get();
+
+        Assert.Contains("LIMIT 5", capturedSql);
+        Assert.Contains("OFFSET 10", capturedSql);
+    }
+
+    [Fact]
+    public async Task From_First_ForcesLimit1InSql()
+    {
+        string? capturedSql = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((sql, _, _ct) => capturedSql = sql)
+            .ReturnsAsync(OkResult());
+
+        await AppAmbitDb.From("tasks").First();
+
+        Assert.Contains("LIMIT 1", capturedSql);
+    }
+
+    [Fact]
+    public async Task From_First_WhenEmpty_ReturnsNull()
+    {
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OkResult(columns: new() { "id" }, rows: new()));
+
+        var result = await AppAmbitDb.From("tasks").First();
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task From_Count_GeneratesCountSql()
+    {
+        string? capturedSql = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((sql, _, _ct) => capturedSql = sql)
+            .ReturnsAsync(OkResult(columns: new() { "COUNT(*)" }, rows: MakeRows(new object?[] { 7 })));
+
+        await AppAmbitDb.From("tasks").Count();
+
+        Assert.Contains("SELECT COUNT(*)", capturedSql);
+        Assert.Contains("FROM \"tasks\"", capturedSql);
+    }
+
+    [Fact]
+    public async Task From_Count_WithWhere_AppliesWhere()
+    {
+        string? capturedSql = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((sql, _, _ct) => capturedSql = sql)
+            .ReturnsAsync(OkResult(columns: new() { "COUNT(*)" }, rows: MakeRows(new object?[] { 3 })));
+
+        var count = await AppAmbitDb.From("tasks").Where("is_completed", 0).Count();
+
+        Assert.Contains("WHERE", capturedSql);
+        Assert.Equal(3, count);
+    }
+
+    // ── Group 4: DbQueryBuilder mutations ────────────────────────────────────
+
+    [Fact]
+    public async Task From_Insert_GeneratesInsertSql()
+    {
+        string? capturedSql = null;
+        List<object?>? capturedParams = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((sql, p, _ct) => { capturedSql = sql; capturedParams = p; })
+            .ReturnsAsync(OkResult(rowsWritten: 1));
+
+        await AppAmbitDb.From("tasks").Insert(new Dictionary<string, object?> { { "title", "Test" }, { "priority", "high" } });
+
+        Assert.Contains("INSERT INTO \"tasks\"", capturedSql);
+        Assert.Contains("\"title\"", capturedSql);
+        Assert.Contains("\"priority\"", capturedSql);
+        Assert.Contains("VALUES (?, ?)", capturedSql);
+        Assert.Equal("Test", capturedParams![0]);
+        Assert.Equal("high", capturedParams![1]);
+    }
+
+    [Fact]
+    public async Task From_Update_WithWhere_GeneratesUpdateSql()
+    {
+        string? capturedSql = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((sql, _, _ct) => capturedSql = sql)
+            .ReturnsAsync(OkResult(rowsWritten: 1));
+
+        await AppAmbitDb.From("tasks")
+            .Where("title", "Test")
+            .Update(new Dictionary<string, object?> { { "is_completed", 1 } });
+
+        Assert.Contains("UPDATE \"tasks\"", capturedSql);
+        Assert.Contains("SET \"is_completed\" = ?", capturedSql);
+        Assert.Contains("WHERE", capturedSql);
+    }
+
+    [Fact]
+    public async Task From_Update_WithoutWhere_ThrowsInvalidOperationException()
+    {
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            AppAmbitDb.From("tasks").Update(new Dictionary<string, object?> { { "is_completed", 1 } }));
+    }
+
+    [Fact]
+    public async Task From_Delete_WithWhere_GeneratesDeleteSql()
+    {
+        string? capturedSql = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((sql, _, _ct) => capturedSql = sql)
+            .ReturnsAsync(OkResult(rowsWritten: 2));
+
+        await AppAmbitDb.From("tasks").Where("is_completed", 1).Delete();
+
+        Assert.Contains("DELETE FROM \"tasks\"", capturedSql);
+        Assert.Contains("WHERE", capturedSql);
+    }
+
+    [Fact]
+    public async Task From_Delete_WithoutWhere_ThrowsInvalidOperationException()
+    {
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            AppAmbitDb.From("tasks").Delete());
+    }
+
+    // ── Group 5: Typed model mapping ──────────────────────────────────────────
+
+    [Fact]
+    public void MapTo_MapsColumnsByPropertyName()
+    {
+        var result = OkResult(
+            columns: new() { "Id", "Title" },
+            rows: MakeRows(new object?[] { 1, "Buy milk" }));
+
+        var items = result.MapTo<SimpleModel>();
+
+        Assert.Single(items);
+        Assert.Equal(1, items[0].Id);
+        Assert.Equal("Buy milk", items[0].Title);
+    }
+
+    [Fact]
+    public void MapTo_MapsColumnsByDbColumnAttribute()
+    {
+        var result = OkResult(
+            columns: new() { "is_completed", "due_date" },
+            rows: MakeRows(new object?[] { 1, "2026-06-10" }));
+
+        var items = result.MapTo<AnnotatedModel>();
+
+        Assert.Single(items);
+        Assert.Equal(1, items[0].IsCompleted);
+        Assert.Equal("2026-06-10", items[0].DueDate);
+    }
+
+    [Fact]
+    public void MapTo_IgnoresUnknownColumns()
+    {
+        var result = OkResult(
+            columns: new() { "Id", "unknown_column" },
+            rows: MakeRows(new object?[] { 5, "ignored" }));
+
+        var items = result.MapTo<SimpleModel>();
+
+        Assert.Single(items);
+        Assert.Equal(5, items[0].Id);
+    }
+
+    [Fact]
+    public void MapTo_HandlesNullValues()
+    {
+        var result = OkResult(
+            columns: new() { "Id", "Title" },
+            rows: MakeRows(new object?[] { 3, null }));
+
+        var items = result.MapTo<SimpleModel>();
+
+        Assert.Single(items);
+        Assert.Equal(3, items[0].Id);
+        Assert.Null(items[0].Title);
+    }
+
+    [Fact]
+    public void MapTo_CastsIntCorrectly()
+    {
+        var result = OkResult(
+            columns: new() { "Id" },
+            rows: MakeRows(new object?[] { 42L })); // long from JSON
+
+        var items = result.MapTo<SimpleModel>();
+
+        Assert.Equal(42, items[0].Id);
+    }
+
+    // ── Group 6: BUG-01 — Offset(0) ──────────────────────────────────────────
+
+    [Fact]
+    public async Task From_Offset_Zero_EmitsOffsetClause()
+    {
+        // BUG-01: guard was > 0, silently dropped OFFSET 0
+        string? capturedSql = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((sql, _, _ct) => capturedSql = sql)
+            .ReturnsAsync(OkResult());
+
+        await AppAmbitDb.From("tasks").Limit(5).Offset(0).Get();
+
+        Assert.Contains("LIMIT 5", capturedSql);
+        Assert.Contains("OFFSET 0", capturedSql);
+    }
+
+    [Fact]
+    public async Task From_Offset_Zero_OnFirst_EmitsOffsetClause()
+    {
+        // Offset(0) must also work when combined with First()
+        string? capturedSql = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((sql, _, _ct) => capturedSql = sql)
+            .ReturnsAsync(OkResult(columns: new() { "id" }, rows: new()));
+
+        await AppAmbitDb.From("tasks").Offset(0).First();
+
+        Assert.Contains("OFFSET 0", capturedSql);
+    }
+
+    // ── Group 7: BUG-03 — bool mapping from integer ───────────────────────────
+
+    [Fact]
+    public void MapTo_Bool_FromInteger1_MapsToTrue()
+    {
+        // BUG-03: bool.Parse("1") throws FormatException — SQLite stores bool as 0/1
+        var result = OkResult(
+            columns: new() { "IsActive" },
+            rows: MakeRows(new object?[] { 1L }));
+
+        var items = result.MapTo<BoolModel>();
+
+        Assert.True(items[0].IsActive);
+    }
+
+    [Fact]
+    public void MapTo_Bool_FromInteger0_MapsToFalse()
+    {
+        var result = OkResult(
+            columns: new() { "IsActive" },
+            rows: MakeRows(new object?[] { 0L }));
+
+        var items = result.MapTo<BoolModel>();
+
+        Assert.False(items[0].IsActive);
+    }
+
+    [Fact]
+    public void MapTo_Bool_FromBoolTrue_MapsCorrectly()
+    {
+        var result = OkResult(
+            columns: new() { "IsActive" },
+            rows: MakeRows(new object?[] { true }));
+
+        var items = result.MapTo<BoolModel>();
+
+        Assert.True(items[0].IsActive);
+    }
+
+    // ── Group 8: BUG-02 — builder consumed guard ─────────────────────────────
+
+    [Fact]
+    public async Task Builder_ExecutedTwice_ThrowsInvalidOperationException()
+    {
+        // BUG-02: reusing builder after execution must be rejected
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OkResult());
+
+        var builder = AppAmbitDb.From("tasks");
+        await builder.Get();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => builder.Get());
+    }
+
+    [Fact]
+    public async Task Builder_FirstThenGet_ThrowsInvalidOperationException()
+    {
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OkResult(columns: new() { "id" }, rows: new()));
+
+        var builder = AppAmbitDb.From("tasks");
+        await builder.First();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => builder.Get());
+    }
+
+    [Fact]
+    public async Task Builder_CountThenDelete_ThrowsInvalidOperationException()
+    {
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OkResult(columns: new() { "COUNT(*)" }, rows: MakeRows(new object?[] { 0 })));
+
+        var builder = AppAmbitDb.From("tasks").Where("is_completed", 1);
+        await builder.Count();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => builder.Delete());
+    }
+
+    // ── Group 9: BUG-04 — API contract consistency ────────────────────────────
+    // Get/First/Count now return empty/null/0 on error (aligned with Execute() HasError pattern)
+
+    [Fact]
+    public async Task From_Get_WhenServiceReturnsError_ReturnsEmptyList()
+    {
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ErrorResult("table not found"));
+
+        var result = await AppAmbitDb.From("tasks").Get();
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task From_First_WhenServiceReturnsError_ReturnsNull()
+    {
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ErrorResult("connection timeout"));
+
+        var result = await AppAmbitDb.From("tasks").First();
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task From_Count_WhenServiceReturnsError_ReturnsZero()
+    {
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ErrorResult("permission denied"));
+
+        var count = await AppAmbitDb.From("tasks").Where("x", 1).Count();
+
+        Assert.Equal(0, count);
+    }
+
+    // ── Group 10: CODE-02 — QuoteId injection guard ───────────────────────────
+
+    [Fact]
+    public void From_TableName_WithDoubleQuote_IsEscapedCorrectly()
+    {
+        // QuoteId must escape " → "" (SQLite identifier escaping)
+        string? capturedSql = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((sql, _, _ct) => capturedSql = sql)
+            .ReturnsAsync(OkResult());
+
+        // Column with embedded quote — must not break SQL
+        _ = AppAmbitDb.From("tasks").Where("col\"name", 1).Get();
+
+        Assert.Contains("\"col\"\"name\"", capturedSql);
+    }
+
+    [Fact]
+    public void From_TableName_WithControlCharacter_ThrowsArgumentException()
+    {
+        // CODE-02: null byte or control char in identifier must be rejected
+        Assert.Throws<ArgumentException>(() =>
+            AppAmbitDb.From("tasks").Where("col\0name", 1));
+    }
+
+    [Fact]
+    public void From_EmptyColumnName_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            AppAmbitDb.From("tasks").Where("", 1));
+    }
+
+    // ── Group 11: CODE-04 — Count() zero/null rows ────────────────────────────
+
+    [Fact]
+    public async Task Count_WhenRowsEmpty_ReturnsZero()
+    {
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OkResult(columns: new() { "COUNT(*)" }, rows: new()));
+
+        var count = await AppAmbitDb.From("tasks").Count();
+
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public async Task Count_WhenValueIsLong_CastsToInt()
+    {
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OkResult(
+                columns: new() { "COUNT(*)" },
+                rows: MakeRows(new object?[] { 99L })));
+
+        var count = await AppAmbitDb.From("tasks").Count();
+
+        Assert.Equal(99, count);
+    }
+
+    // ── Group 12: multiple Where() conditions ────────────────────────────────
+
+    [Fact]
+    public async Task From_MultipleWhere_JoinsWithAnd()
+    {
+        string? capturedSql = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((sql, _, _ct) => capturedSql = sql)
+            .ReturnsAsync(OkResult());
+
+        await AppAmbitDb.From("tasks")
+            .Where("is_completed", 0)
+            .Where("priority", "high")
+            .Get();
+
+        Assert.Contains("WHERE", capturedSql);
+        Assert.Contains("AND", capturedSql);
+        Assert.Contains("\"is_completed\" = ?", capturedSql);
+        Assert.Contains("\"priority\" = ?", capturedSql);
+    }
+
+    [Fact]
+    public async Task From_MultipleWhere_ForwardsAllParams()
+    {
+        List<object?>? capturedParams = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((_, p, _ct) => capturedParams = p)
+            .ReturnsAsync(OkResult());
+
+        await AppAmbitDb.From("tasks")
+            .Where("is_completed", 0)
+            .Where("priority", "high")
+            .Get();
+
+        Assert.Equal(2, capturedParams!.Count);
+        Assert.Equal(0, capturedParams[0]);
+        Assert.Equal("high", capturedParams[1]);
+    }
+
+    // ── Group 13: Insert edge cases ───────────────────────────────────────────
+
+    [Fact]
+    public async Task From_Insert_WithNullValue_IncludesNullParam()
+    {
+        List<object?>? capturedParams = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((_, p, _ct) => capturedParams = p)
+            .ReturnsAsync(OkResult(rowsWritten: 1));
+
+        await AppAmbitDb.From("tasks").Insert(new Dictionary<string, object?>
+        {
+            { "title", "Test" },
+            { "due_date", null }
+        });
+
+        Assert.Equal(2, capturedParams!.Count);
+        Assert.Null(capturedParams[1]);
+    }
+
+    [Fact]
+    public async Task From_Update_ParamsOrderIsSetClauseThenWhere()
+    {
+        // UPDATE SET params must come before WHERE params
+        List<object?>? capturedParams = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((_, p, _ct) => capturedParams = p)
+            .ReturnsAsync(OkResult(rowsWritten: 1));
+
+        await AppAmbitDb.From("tasks")
+            .Where("id", 42)
+            .Update(new Dictionary<string, object?> { { "is_completed", 1 } });
+
+        // params: [SET value=1, WHERE id=42]
+        Assert.Equal(2, capturedParams!.Count);
+        Assert.Equal(1, capturedParams[0]); // SET value
+        Assert.Equal(42, capturedParams[1]); // WHERE value
+    }
+
+    // ── Group 14: WhereIn edge cases ─────────────────────────────────────────
+
+    [Fact]
+    public async Task From_WhereIn_SingleValue_GeneratesInWithOnePlaceholder()
+    {
+        string? capturedSql = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((sql, _, _ct) => capturedSql = sql)
+            .ReturnsAsync(OkResult());
+
+        await AppAmbitDb.From("tasks").WhereIn("priority", new object?[] { "high" }).Get();
+
+        Assert.Contains("IN (?)", capturedSql);
+    }
+
+    [Fact]
+    public async Task From_WhereIn_WithNullValue_IncludesNullParam()
+    {
+        List<object?>? capturedParams = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((_, p, _ct) => capturedParams = p)
+            .ReturnsAsync(OkResult());
+
+        await AppAmbitDb.From("tasks").WhereIn("priority", new object?[] { "high", null }).Get();
+
+        Assert.Equal(2, capturedParams!.Count);
+        Assert.Null(capturedParams[1]);
+    }
+
+    // ── Group 15: CODE-06 — OrWhere and WhereGroup ───────────────────────────
+
+    [Fact]
+    public async Task From_OrWhere_GeneratesOrInSql()
+    {
+        string? capturedSql = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((sql, _, _ct) => capturedSql = sql)
+            .ReturnsAsync(OkResult());
+
+        await AppAmbitDb.From("tasks")
+            .Where("priority", "high")
+            .OrWhere("priority", "medium")
+            .Get();
+
+        Assert.Contains("OR", capturedSql);
+        Assert.Contains("\"priority\" = ?", capturedSql);
+    }
+
+    [Fact]
+    public async Task From_OrWhere_ForwardsAllParams()
+    {
+        List<object?>? capturedParams = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((_, p, _ct) => capturedParams = p)
+            .ReturnsAsync(OkResult());
+
+        await AppAmbitDb.From("tasks")
+            .Where("priority", "high")
+            .OrWhere("priority", "medium")
+            .Get();
+
+        Assert.Equal(2, capturedParams!.Count);
+        Assert.Equal("high", capturedParams[0]);
+        Assert.Equal("medium", capturedParams[1]);
+    }
+
+    [Fact]
+    public async Task From_WhereGroup_GeneratesParenthesizedGroup()
+    {
+        string? capturedSql = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((sql, _, _ct) => capturedSql = sql)
+            .ReturnsAsync(OkResult());
+
+        await AppAmbitDb.From("tasks")
+            .Where("is_completed", 0)
+            .WhereGroup(g => g.Where("priority", "high").Where("due_date", "2026-01-01"))
+            .Get();
+
+        Assert.Contains("WHERE", capturedSql);
+        Assert.Contains("(", capturedSql);
+        Assert.Contains(")", capturedSql);
+        Assert.Contains("AND", capturedSql);
+    }
+
+    [Fact]
+    public void OrWhere_InvalidOperator_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            AppAmbitDb.From("tasks").OrWhere("col", "DROP", "val"));
+    }
+
+    // ── Group 16: CODE-05 — CancellationToken propagation ────────────────────
+
+    [Fact]
+    public async Task Execute_WithCancellationToken_PropagatesToken()
+    {
+        CancellationToken? capturedToken = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((_, _, ct) => capturedToken = ct)
+            .ReturnsAsync(OkResult());
+
+        using var cts = new CancellationTokenSource();
+        await AppAmbitDb.Execute("SELECT 1", cts.Token);
+
+        Assert.NotNull(capturedToken);
+    }
+
+    [Fact]
+    public async Task From_Get_WithCancelledToken_DoesNotCallService()
+    {
+        // CancellationToken passed to QueryAsync — service should receive it
+        CancellationToken? capturedToken = null;
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<object?>?, CancellationToken>((_, _, ct) => capturedToken = ct)
+            .ReturnsAsync(OkResult());
+
+        using var cts = new CancellationTokenSource();
+        await AppAmbitDb.From("tasks").Get(cts.Token);
+
+        Assert.NotNull(capturedToken);
+        Assert.Equal(cts.Token, capturedToken);
+    }
+
+    // ── Group 17: BUG-05 — AppAmbitDb.Initialize re-init guard ───────────────
+
+    [Fact]
+    public void Initialize_SameInstance_DoesNotWarn()
+    {
+        // Re-initializing with same instance: no-op, no warning
+        var mock = new Mock<IDbService>();
+        AppAmbitDb.Initialize(mock.Object);
+        AppAmbitDb.Initialize(mock.Object); // same instance — should be fine
+    }
+
+    [Fact]
+    public void Initialize_DifferentInstance_OverwritesSilently()
+    {
+        // Re-initializing with different instance: overwrites (warning via Debug.WriteLine, not throw)
+        var mock1 = new Mock<IDbService>();
+        var mock2 = new Mock<IDbService>();
+        AppAmbitDb.Initialize(mock1.Object);
+        AppAmbitDb.Initialize(mock2.Object); // different instance — logs warning, doesn't throw
+    }
+
+    // ── Group 18: CODE-04 — Count unexpected type throws ─────────────────────
+
+    [Fact]
+    public async Task Count_WhenValueIsUnexpectedType_Throws()
+    {
+        _mockDb.Setup(s => s.QueryAsync(It.IsAny<string>(), It.IsAny<List<object?>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(OkResult(
+                columns: new() { "COUNT(*)" },
+                rows: MakeRows(new object?[] { new object() }))); // non-IConvertible value
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            AppAmbitDb.From("tasks").Count());
+    }
+
+    // ── inner test models ─────────────────────────────────────────────────────
+
+    private class SimpleModel
+    {
+        public int Id { get; set; }
+        public string? Title { get; set; }
+    }
+
+    private class AnnotatedModel
+    {
+        [DbColumn("is_completed")]
+        public int IsCompleted { get; set; }
+
+        [DbColumn("due_date")]
+        public string? DueDate { get; set; }
+    }
+
+    private class BoolModel
+    {
+        public bool IsActive { get; set; }
+    }
+}

--- a/tests/DbServiceTests.cs
+++ b/tests/DbServiceTests.cs
@@ -1,0 +1,216 @@
+using AppAmbit.Enums;
+using AppAmbit.Models.Db;
+using AppAmbit.Models.Responses;
+using AppAmbit.Services;
+using AppAmbit.Services.Endpoints;
+using AppAmbit.Services.Interfaces;
+using Moq;
+using Xunit;
+
+namespace AppAmbitTest;
+
+[Collection("DbService Tests")]
+public class DbServiceTests
+{
+    private readonly Mock<IAPIService> _mockApi;
+    private readonly DbService _service;
+
+    public DbServiceTests()
+    {
+        _mockApi = new Mock<IAPIService>();
+        _service = new DbService(_mockApi.Object);
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private void SetupQueryResponse(DbApiResponse response) =>
+        _mockApi
+            .Setup(s => s.ExecuteRequest<DbApiResponse>(It.IsAny<DbQueryEndpoint>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ApiResult<DbApiResponse>.Success(response));
+
+    private void SetupBatchResponse(DbApiResponse response) =>
+        _mockApi
+            .Setup(s => s.ExecuteRequest<DbApiResponse>(It.IsAny<DbBatchEndpoint>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ApiResult<DbApiResponse>.Success(response));
+
+    private void SetupQueryError(ApiErrorType errorType, string message) =>
+        _mockApi
+            .Setup(s => s.ExecuteRequest<DbApiResponse>(It.IsAny<DbQueryEndpoint>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ApiResult<DbApiResponse>.Fail(errorType, message));
+
+    private static DbApiResponse MakeResponse(params DbResultDto[] dtos) =>
+        new() { Results = dtos.ToList() };
+
+    private static DbResultDto MakeDto(
+        List<string>? columns = null,
+        List<List<object?>>? rows = null,
+        int rowsRead = 0,
+        int rowsWritten = 0,
+        string? error = null) =>
+        new()
+        {
+            Columns = columns ?? new(),
+            Rows = rows ?? new(),
+            RowsRead = rowsRead,
+            RowsWritten = rowsWritten,
+            Error = error
+        };
+
+    // ── QueryAsync ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task QueryAsync_SuccessResponse_ReturnsFirstResult()
+    {
+        SetupQueryResponse(MakeResponse(MakeDto(
+            columns: new() { "id", "title" },
+            rows: new() { new List<object?> { 1, "Buy milk" } },
+            rowsRead: 1)));
+
+        var result = await _service.QueryAsync("SELECT * FROM tasks");
+
+        Assert.False(result.HasError);
+        Assert.Equal(1, result.RowsRead);
+        Assert.Equal(2, result.Columns.Count);
+        Assert.Single(result.Rows);
+    }
+
+    [Fact]
+    public async Task QueryAsync_UsesDbApiResponseType_NotRawString()
+    {
+        // This is the root-cause regression test.
+        // Before the fix, DbService called ExecuteRequest<string>, which caused
+        // APIService.TryDeserializeJson<string> to throw "Could not parse JSON."
+        // Now it calls ExecuteRequest<DbApiResponse> — verify the correct type is used.
+        SetupQueryResponse(MakeResponse(MakeDto(rowsWritten: 1)));
+
+        await _service.QueryAsync("INSERT INTO t VALUES (1)");
+
+        _mockApi.Verify(s => s.ExecuteRequest<DbApiResponse>(
+            It.IsAny<DbQueryEndpoint>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        // Confirm ExecuteRequest<string> was NEVER called
+        _mockApi.Verify(s => s.ExecuteRequest<string>(
+            It.IsAny<IEndpoint>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task QueryAsync_ApiNetworkError_ReturnsDbResultWithError()
+    {
+        SetupQueryError(ApiErrorType.NetworkUnavailable, "No internet available");
+
+        var result = await _service.QueryAsync("SELECT 1");
+
+        Assert.True(result.HasError);
+        // CODE-07: raw API message sanitized — user sees safe message, raw msg in Debug.WriteLine
+        Assert.Contains("Network unavailable", result.Error);
+    }
+
+    [Fact]
+    public async Task QueryAsync_ApiReturnsNull_ReturnsDbResultWithError()
+    {
+        _mockApi
+            .Setup(s => s.ExecuteRequest<DbApiResponse>(It.IsAny<DbQueryEndpoint>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ApiResult<DbApiResponse>?)null);
+
+        var result = await _service.QueryAsync("SELECT 1");
+
+        Assert.True(result.HasError);
+    }
+
+    [Fact]
+    public async Task QueryAsync_EmptyResults_ReturnsErrorResult()
+    {
+        SetupQueryResponse(new DbApiResponse { Results = new() });
+
+        var result = await _service.QueryAsync("SELECT 1");
+
+        Assert.True(result.HasError);
+        // CODE-07: sanitized message — no internal detail exposed
+        Assert.NotEmpty(result.Error!);
+    }
+
+    [Fact]
+    public async Task QueryAsync_WithParams_PassesSqlCorrectly()
+    {
+        string? capturedSql = null;
+        _mockApi
+            .Setup(s => s.ExecuteRequest<DbApiResponse>(It.IsAny<DbQueryEndpoint>(), It.IsAny<CancellationToken>()))
+            .Callback<IEndpoint, CancellationToken>((ep, _) =>
+            {
+                // Verify endpoint payload has the SQL
+                var payload = ep.Payload as AppAmbit.Models.Db.DbQueryRequest;
+                capturedSql = payload?.Sql;
+            })
+            .ReturnsAsync(ApiResult<DbApiResponse>.Success(MakeResponse(MakeDto())));
+
+        await _service.QueryAsync("SELECT * FROM tasks WHERE id = ?", new List<object?> { 5 });
+
+        Assert.Equal("SELECT * FROM tasks WHERE id = ?", capturedSql);
+    }
+
+    // ── BatchAsync ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task BatchAsync_SuccessResponse_ReturnsAllResults()
+    {
+        SetupBatchResponse(MakeResponse(
+            MakeDto(rowsWritten: 1),
+            MakeDto(rowsWritten: 1),
+            MakeDto(columns: new() { "COUNT(*)" }, rows: new() { new List<object?> { 2 } }, rowsRead: 1)));
+
+        var results = await _service.BatchAsync(new[]
+        {
+            DbStatement.Of("INSERT INTO t VALUES (1)"),
+            DbStatement.Of("INSERT INTO t VALUES (2)"),
+            DbStatement.Of("SELECT COUNT(*) FROM t")
+        }, false);
+
+        Assert.Equal(3, results.Count);
+        Assert.Equal(1, results[0].RowsWritten);
+        Assert.Equal(1, results[1].RowsWritten);
+        Assert.Equal(1, results[2].RowsRead);
+    }
+
+    [Fact]
+    public async Task BatchAsync_UsesDbApiResponseType_NotRawString()
+    {
+        SetupBatchResponse(MakeResponse(MakeDto(rowsWritten: 1)));
+
+        await _service.BatchAsync(new[] { DbStatement.Of("INSERT INTO t VALUES (1)") }, false);
+
+        _mockApi.Verify(s => s.ExecuteRequest<DbApiResponse>(
+            It.IsAny<DbBatchEndpoint>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        _mockApi.Verify(s => s.ExecuteRequest<string>(
+            It.IsAny<IEndpoint>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task BatchAsync_ApiNetworkError_ReturnsListWithError()
+    {
+        _mockApi
+            .Setup(s => s.ExecuteRequest<DbApiResponse>(It.IsAny<DbBatchEndpoint>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ApiResult<DbApiResponse>.Fail(ApiErrorType.NetworkUnavailable, "No internet available"));
+
+        var results = await _service.BatchAsync(new[] { DbStatement.Of("INSERT INTO t VALUES (1)") }, true);
+
+        Assert.Single(results);
+        Assert.True(results[0].HasError);
+    }
+
+    [Fact]
+    public async Task BatchAsync_InTransaction_UsesBatchEndpoint()
+    {
+        SetupBatchResponse(MakeResponse(MakeDto(rowsWritten: 1)));
+
+        await _service.BatchAsync(new[] { DbStatement.Of("INSERT INTO t VALUES (1)") }, inTransaction: true);
+
+        _mockApi.Verify(s => s.ExecuteRequest<DbApiResponse>(
+            It.IsAny<DbBatchEndpoint>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] 🛠️ Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📚 Documentation Update

## Description

Adds Database-as-a-Service (DBaaS) to the AppAmbit .NET SDK. Developers can now read and write data to their app-linked database directly from the SDK — no manual HTTP calls needed.

Two ways to interact with the database:

- **Raw SQL** — execute any SQL statement directly
- **Fluent builder** — chain readable methods (`Where`, `OrderBy`, `Limit`, `Insert`, `Update`, `Delete`, etc.) that compile to safe parameterized SQL automatically

Both support typed model mapping, batch operations, cancellation, and consistent error handling.

Also includes a Database demo screen in all 4 sample apps (MAUI, Avalonia, Native Android, Native iOS) with 16 preset queries covering the full CRUD lifecycle.

**Bug fixes found during review:**

- Pagination with `Offset(0)` was silently ignored
- Reusing a query builder corrupted the SQL — now enforced as single-use
- Boolean values stored as `0`/`1` in the database threw an error when read back
- Internal API error messages were leaking raw server detail to the UI — now sanitized
- A service was being initialized twice on startup

## Related Tickets & Documents

Closes #ID-1652

## QA Instructions

1. Open the Database screen in any sample app
2. Run preset queries in order: **Create → Insert → Select → Update → Delete**
3. Confirm Update and Delete reflect the correct row counts
4. Run the **Batch** demo and verify all statements commit together
5. On MAUI iOS — confirm all 5 tabs are visible (no "More" overflow)
6. On Avalonia — confirm the "DB" nav button is visible without clipping

## Added/updated tests?


- [x] ✅ Yes — 99 tests passing, 31 new tests covering all bug fixes and new builder features
- [ ] ❌ No.
- [ ] 🤔 I need help with writing tests

## Are there any post deployment tasks we need to perform?

- [ ] 📝 Yes
- [x] ❌ No
- [ ] ❓ I don't know
